### PR TITLE
Fix: capture host upstream resolvers reliably on `up` (issue #2)

### DIFF
--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -149,6 +149,31 @@ UP_ARGS="up"
 # NetBird's built-in SSH server (host-wide global toggle from netbird.cfg).
 # Unraid is root-operated, so also permit root login (refused otherwise).
 [ "$ENABLE_SSH" = "1" ]  && UP_ARGS="$UP_ARGS --allow-server-ssh --enable-ssh-root"
+
+# Guard against a stale NetBird-managed /etc/resolv.conf surviving an ungraceful
+# shutdown (reboot, SIGKILL, array stop). If it points only at NetBird's own
+# embedded resolver (100.64.0.0/10) while the daemon is down, the host can't
+# resolve anything -- including the management domain -- so `up` fails with a
+# connect timeout (issue #2, ungraceful-exit case). If the current resolv.conf
+# has no usable upstream, recover one before connecting: prefer NetBird's saved
+# original, else fall back to public resolvers. Runs regardless of MANAGE_DNS,
+# since with --disable-dns NetBird won't fix a stale file on its own.
+nb_cgnat='^100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\.'
+nb_has_usable_upstream() { # $1=file; 0 if it lists a nameserver outside 100.64/10
+    sed -nE 's/^[[:space:]]*nameserver[[:space:]]+([^[:space:]#]+).*/\1/p' "$1" 2>/dev/null \
+        | grep -qvE "$nb_cgnat"
+}
+if [ -r /etc/resolv.conf ] && ! nb_has_usable_upstream /etc/resolv.conf; then
+    if [ -r /etc/resolv.conf.original.netbird ] && nb_has_usable_upstream /etc/resolv.conf.original.netbird; then
+        cp -a /etc/resolv.conf.original.netbird /etc/resolv.conf \
+            && log "Recovered /etc/resolv.conf from .original.netbird (no usable upstream; issue #2)."
+    else
+        cp -a /etc/resolv.conf "/etc/resolv.conf.preNB.$(date +%s)" 2>/dev/null
+        printf '# Written by netbird-unraid recovery (issue #2)\nnameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /etc/resolv.conf \
+            && log "WARN: no usable upstream in resolv.conf or saved original; wrote fallback (1.1.1.1/8.8.8.8) (issue #2)."
+    fi
+fi
+
 # DNS management (host-wide global toggle from netbird.cfg). Default manages DNS
 # (NetBird's embedded resolver rewrites /etc/resolv.conf); MANAGE_DNS=0 passes
 # --disable-dns so NetBird leaves host DNS alone (issue #2). Explicit boolean so
@@ -157,6 +182,21 @@ if [ "$MANAGE_DNS" = "0" ] || [ "$MANAGE_DNS" = "false" ]; then
     UP_ARGS="$UP_ARGS --disable-dns=true"
 else
     UP_ARGS="$UP_ARGS --disable-dns=false"
+    # Unraid's rc.inet1 writes resolv.conf with inline comments on each line,
+    # e.g. "nameserver 1.1.1.1  # eth0:v4". NetBird can't parse a nameserver off
+    # a commented line, so it captures zero upstreams and its resolver refuses
+    # ordinary lookups (issue #2). Strip the trailing comments off nameserver
+    # lines just before `up` so NetBird records the real upstreams and split DNS
+    # works out of the box. The comments are informational only. Skipped when DNS
+    # management is off (NetBird leaves resolv.conf alone in that case).
+    if grep -qE '^[[:space:]]*nameserver[[:space:]]+[^[:space:]#]+[[:space:]]*#' /etc/resolv.conf 2>/dev/null; then
+        if cp -a /etc/resolv.conf "/etc/resolv.conf.preNB.$(date +%s)" 2>/dev/null \
+           && sed -i -E 's/^([[:space:]]*nameserver[[:space:]]+[^[:space:]#]+).*/\1/' /etc/resolv.conf 2>/dev/null; then
+            log "Stripped inline comments from /etc/resolv.conf nameserver lines (issue #2)."
+        else
+            log "WARN: could not sanitize /etc/resolv.conf; DNS forwarding may not work (issue #2)."
+        fi
+    fi
 fi
 
 log "Running: netbird up (profile '$PROFILE', mode '$MODE')"


### PR DESCRIPTION
## Summary

On Unraid, bringing NetBird up could leave the host unable to resolve ordinary internet names — NetBird domains and raw IPs worked, but public lookups returned `REFUSED` / "recursion not available". The cause is that NetBird's embedded resolver becomes the host's only nameserver but fails to record a working *upstream* to forward non-NetBird queries to, so it has nothing to forward to.

This PR fixes the two ways that upstream capture breaks on Unraid, both in the `up` path of `apply.sh`, so split DNS works out of the box without requiring the user to configure a Nameserver group or disable DNS management.

Fixes #2.

## Background

When NetBird comes up it starts its own DNS resolver and rewrites `/etc/resolv.conf` to point at itself (for split DNS), recording the previous nameservers as the upstreams it forwards unmatched queries to. Two Unraid specifics break that capture:

1. **Inline comments.** Unraid's `rc.inet1` writes `/etc/resolv.conf` with trailing comments on each line, e.g. `nameserver 1.1.1.1  # eth0:v4`. NetBird (0.71.4) doesn't parse a nameserver off a commented line, so it captures **zero** upstreams. Confirmed by @Selmaks in issue #2: stripping the comments makes NetBird log `registering original nameservers [1.1.1.1] as upstream handlers` and DNS works again. Hosts that don't use this format (Windows, Raspberry Pi) were never affected.

2. **Stale `resolv.conf` after an ungraceful shutdown.** If the daemon exits without a clean `down` (reboot, SIGKILL, array stop), `/etc/resolv.conf` is left pointing only at NetBird's own embedded resolver (`100.64.0.0/10`). With the daemon down that resolver is dead, so the host can't resolve anything — including the management domain — and the next `up` fails with a connect timeout (chicken-and-egg: NetBird needs DNS to reach management before it can rewrite `resolv.conf`).

## Changes

`src/usr/local/emhttp/plugins/netbird/scripts/apply.sh`, in the `up` path:

- **Stale-resolv.conf recovery guard** (runs before connecting, regardless of the Manage DNS setting). If `/etc/resolv.conf` lists no usable upstream — i.e. only NetBird's `100.64.0.0/10` range — it recovers one before `up`: it restores `/etc/resolv.conf.original.netbird` when that backup carries a real upstream, otherwise it writes a public fallback (`1.1.1.1` / `8.8.8.8`) so the daemon can reach management. The check is self-limiting: when a usable upstream is already present it does nothing.

- **Inline-comment sanitize** (Manage-DNS-on path only). Just before `up`, if a `nameserver` line carries a trailing comment, strip the comment so NetBird records the real upstreams. A backup is taken first; the comments are purely informational (`# eth0:v4`).

No behavior change for hosts that already capture upstreams correctly — both guards are no-ops when `/etc/resolv.conf` already has clean, usable nameservers.

## Testing

Verified end-to-end on real Unraid hardware (NetBird 0.71.4, GNU sed 4.9 / grep 3.12):

- **Reproduced** the bug: a commented `resolv.conf` → `nslookup bluesnews.com` `REFUSED`, `Nameservers: 0/0`, no upstream registered.
- **Comment sanitize:** after stripping, `up` logs `registering original nameservers [1.1.1.1] as upstream handlers`, public names resolve, and NetBird names still resolve (split DNS intact).
- **Recovery guard:** a stale NetBird-only `resolv.conf` made the management domain time out; the guard restored the real upstream, after which `up` connected successfully. CGNAT-range detection validated across 8 edge cases (`100.64`–`100.127` treated as NetBird; `100.63` and `100.128` treated as usable).
- Host restored to its original state after testing.

## Notes / follow-ups

- The real fix for case (1) belongs upstream in NetBird's `resolv.conf` parser (handling inline comments); worth filing at netbirdio/netbird. Once that ships, the sanitize step becomes redundant — it is harmless but keeps running, so it should be gated on NetBird version or removed at that point. The recovery guard remains useful regardless, since it addresses a separate bootstrap failure.
- The recovery fallback writes public resolvers only when no usable upstream exists anywhere; if a user's management server is internal-DNS-only, that fallback won't resolve it (nothing would in that state — a WARN is logged).


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/netbird-unraid/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->