### PR TITLE
feat: add release publishing and changelog automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,71 @@
+# Release Drafter config for the NetBird Unraid plugin.
+#
+# Builds the changelog shown in Unraid's plugin update popup from the plugin's
+# own merged PRs, grouped by the label an autolabeler assigns from each PR's
+# conventional-commit title. The drafted release body is injected verbatim into
+# the .plg <CHANGES> block by .github/workflows/release.yml on publish.
+
+categories:
+  - title: "New Features"
+    labels:
+      - "feat"
+  - title: "Bug Fixes"
+    labels:
+      - "fix"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "refactor"
+
+# Bold sub-labels nest cleanly under the "### <version>" heading that the release
+# workflow prepends — Unraid renders **bold** inline rather than as a same-level
+# header (which "###" would produce).
+category-template: "**$TITLE**"
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+
+# Single body section: just the categorized changes. The version heading and the
+# "Older releases" footer are added at inject time by the release workflow.
+template: |
+  $CHANGES
+
+# Strip the conventional-commit prefix from the PR title in the changelog.
+replacers:
+  - search: '/^(feat|fix|chore|refactor)(\([^)]*\))?:\s*/'
+    replace: ""
+
+# Keep purely internal PRs out of the user-facing changelog.
+exclude-labels:
+  - "docs"
+  - "test"
+  - "ci"
+  - "perf"
+  - "translation"
+
+# Label open PRs automatically from their conventional-commit title so the
+# categories above work without manual labeling.
+autolabeler:
+  - label: "feat"
+    title:
+      - '/^feat(\([^)]*\))?!?:/'
+  - label: "fix"
+    title:
+      - '/^fix(\([^)]*\))?!?:/'
+  - label: "chore"
+    title:
+      - '/^chore(\([^)]*\))?!?:/'
+  - label: "refactor"
+    title:
+      - '/^refactor(\([^)]*\))?!?:/'
+  - label: "docs"
+    title:
+      - '/^docs(\([^)]*\))?!?:/'
+  - label: "test"
+    title:
+      - '/^test(\([^)]*\))?!?:/'
+  - label: "ci"
+    title:
+      - '/^ci(\([^)]*\))?!?:/'
+  - label: "perf"
+    title:
+      - '/^perf(\([^)]*\))?!?:/'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,43 @@
+name: Draft release
+
+# Keeps a single draft GitHub Release up to date with the categorized changelog
+# of merged PRs since the last published release (see .github/release-drafter.yml).
+#
+# - push to main:           (re)draft the release, tagged with a timestamp version.
+# - pull_request_target:    autolabel the PR from its conventional-commit title so
+#                           it lands in the right changelog category once merged.
+#
+# Publishing the draft (in the GitHub UI) is what triggers .github/workflows/
+# release.yml to build and ship — the maintainer controls when a release cuts.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Timestamp version matching the plugin's YYYY.MM.DD.HHMM scheme. Passed to
+      # release-drafter as the draft's name + tag (it can't derive a time-based
+      # version itself). Only meaningful on push; harmless on PR autolabel runs.
+      - name: Compute version
+        run: echo "VERSION=$(date -u +%Y.%m.%d.%H%M)" >> "$GITHUB_ENV"
+
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          name: ${{ env.VERSION }}
+          tag: ${{ env.VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: PR title
+
+# Validates that PR titles follow Conventional Commits so the autolabeler in
+# .github/release-drafter.yml can sort each PR into the right changelog category.
+# Remove this workflow if you'd rather not gate PRs on title format.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            refactor
+            docs
+            test
+            ci
+            perf
+            revert

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,23 @@
 name: Release
 
-# Manually-triggered release workflow.
-#
-# What it does:
-#   1. Resolves the NetBird upstream version to ship (input or 'latest').
-#   2. Pulls the SHA256 of netbird_<ver>_linux_amd64.tar.gz directly from
-#      github.com/netbirdio/netbird releases.
-#   3. Updates plugin/netbird.plg + plugin/plugin.json with that version + hash.
-#   4. Runs scripts/build.sh to produce dist/*.txz and dist/netbird.plg.
-#   5. Prepends a CHANGES entry with the new plugin version + NetBird version.
-#   6. Commits, tags, pushes, and creates a GitHub Release with the .txz asset.
+# Runs when a drafted GitHub Release is published (see .github/workflows/
+# draft-release.yml). Builds the plugin package + .plg, injects the release's
+# categorized changelog into the .plg <CHANGES> block, commits the built .plg
+# back to main (so the pluginURL serves accurate metadata + changelog), and
+# uploads the .txz asset to the release.
 #
 # Prereqs (one-time):
-#   - Repo Settings → Actions → General → "Workflow permissions":
-#         Read and write permissions  ✓
-#         Allow GitHub Actions to create and approve pull requests  ✓
-#   - No secrets needed; uses the default GITHUB_TOKEN.
+#   - Repo Settings -> Actions -> "Read and write permissions".
 
 on:
-  # Daily check for a new NetBird upstream release. The "Detect unchanged" step
-  # below skips the build/commit/release unless the resolved version differs
-  # from what's pinned, so this is a no-op on days with no upstream release.
-  schedule:
-    - cron: '0 7 * * *'
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
-      netbird_version:
-        description: 'NetBird version to pin (e.g. 0.71.3, or "latest")'
-        required: false
-        default: 'latest'
-      force:
-        description: 'Force a release even if NetBird version is unchanged'
-        required: false
-        type: boolean
-        default: false
+      tag:
+        description: 'Existing release tag to (re)build, e.g. 2026.05.27.1742'
+        required: true
 
 permissions:
   contents: write
@@ -45,171 +29,117 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history so the tag check + push work
+          ref: main
+          fetch-depth: 0
 
-      - name: Resolve NetBird version
-        id: nb
+      - name: Resolve release
+        id: rel
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          REQ='${{ inputs.netbird_version }}'
-          if [ -z "$REQ" ] || [ "$REQ" = "latest" ]; then
-              TAG=$(gh release view --repo netbirdio/netbird --json tagName --jq .tagName)
+          if [ "${{ github.event_name }}" = "release" ]; then
+              TAG='${{ github.event.release.tag_name }}'
           else
-              # Accept "0.71.3" or "v0.71.3"
-              TAG="${REQ#v}"
-              TAG="v${TAG}"
+              TAG='${{ inputs.tag }}'
           fi
-          VER="${TAG#v}"
-          ASSET="netbird_${VER}_linux_amd64.tar.gz"
-
-          # Pull the digest GitHub already stores for the asset.
-          DIGEST=$(gh release view "$TAG" --repo netbirdio/netbird \
-              --json assets --jq ".assets[] | select(.name == \"$ASSET\") | .digest")
-          if [ -z "$DIGEST" ]; then
-              echo "::error::Asset $ASSET not found in netbirdio/netbird@$TAG"
+          if [ -z "$TAG" ]; then
+              echo "::error::No release tag to build."
               exit 1
           fi
-          SHA256="${DIGEST#sha256:}"
-
-          # Defense in depth: download + verify locally so we don't trust the API alone.
-          URL="https://github.com/netbirdio/netbird/releases/download/${TAG}/${ASSET}"
-          curl -fsSL -o /tmp/nb.tgz "$URL"
-          ACTUAL=$(sha256sum /tmp/nb.tgz | awk '{print $1}')
-          if [ "$ACTUAL" != "$SHA256" ]; then
-              echo "::error::SHA256 mismatch: API=$SHA256 actual=$ACTUAL"
-              exit 1
-          fi
-          rm -f /tmp/nb.tgz
-
-          echo "tag=$TAG"       >> "$GITHUB_OUTPUT"
-          echo "version=$VER"   >> "$GITHUB_OUTPUT"
-          echo "asset=$ASSET"   >> "$GITHUB_OUTPUT"
-          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-          echo "url=$URL"       >> "$GITHUB_OUTPUT"
-
-      - name: Detect unchanged upstream
-        id: changed
-        run: |
-          CUR=$(sed -nE 's/.*<!ENTITY netbirdVer\s+"([^"]+)".*/\1/p' plugin/netbird.plg | head -1)
-          echo "current=$CUR" >> "$GITHUB_OUTPUT"
-          if [ "$CUR" = "${{ steps.nb.outputs.version }}" ] && [ "${{ inputs.force }}" != "true" ]; then
-              echo "::notice::NetBird already pinned at $CUR. Re-run with force=true to release anyway."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Bail out (unchanged)
-        if: steps.changed.outputs.skip == 'true'
-        run: exit 0
-
-      - name: Update plugin/netbird.plg + plugin/plugin.json
-        if: steps.changed.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          NB_VER='${{ steps.nb.outputs.version }}'
-          NB_SHA='${{ steps.nb.outputs.sha256 }}'
-
-          sed -i -E 's|(<!ENTITY netbirdVer\s+")[^"]+(">)|\1'"$NB_VER"'\2|' plugin/netbird.plg
-          sed -i -E 's|(<!ENTITY netbirdSHA256\s+")[^"]+(">)|\1'"$NB_SHA"'\2|' plugin/netbird.plg
-
-          # plugin.json mirror (documentation only)
-          tmp=$(mktemp)
-          jq --arg v "$NB_VER" --arg s "$NB_SHA" \
-              '.netbirdVersion = $v | .netbirdSHA256 = $s' plugin/plugin.json > "$tmp"
-          mv "$tmp" plugin/plugin.json
-
-          echo "--- updated plugin/netbird.plg ---"
-          grep -E 'netbirdVer|netbirdSHA256' plugin/netbird.plg | head -2
-          echo "--- updated plugin/plugin.json ---"
-          jq '{netbirdVersion, netbirdSHA256}' plugin/plugin.json
+          # Fetch the drafted/published body via the API (avoids interpolating
+          # untrusted release text straight into the shell).
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body \
+              > /tmp/release_body.md || true
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build .txz + finalized .plg
-        if: steps.changed.outputs.skip != 'true'
+        env:
+          VERSION: ${{ steps.rel.outputs.tag }}
         run: ./scripts/build.sh
 
-      - name: Read new plugin version
-        if: steps.changed.outputs.skip != 'true'
-        id: build
-        run: |
-          PV=$(sed -nE 's/.*<!ENTITY version\s+"([^"]+)".*/\1/p' dist/netbird.plg | head -1)
-          PKG=$(ls dist/unraid-netbird-utils-*.txz | head -1)
-          echo "plugin_version=$PV"       >> "$GITHUB_OUTPUT"
-          echo "pkg_file=$(basename $PKG)" >> "$GITHUB_OUTPUT"
-          echo "pkg_path=$PKG"            >> "$GITHUB_OUTPUT"
-
-      - name: Prepend CHANGES entry
-        if: steps.changed.outputs.skip != 'true'
+      - name: Inject changelog into <CHANGES>
+        env:
+          TAG: ${{ steps.rel.outputs.tag }}
         run: |
           set -euo pipefail
-          PV='${{ steps.build.outputs.plugin_version }}'
-          NV='${{ steps.nb.outputs.version }}'
-
-          # Insert a new "### PV\n- Update NetBird to NV" block right after the
-          # opening <![CDATA[ of the CHANGES section. Keep historic entries
-          # below intact so the changelog grows over time.
-          python3 - <<'PY' "$PV" "$NV"
+          python3 - "$TAG" <<'PY'
           import re, sys, pathlib
-          pv, nv = sys.argv[1], sys.argv[2]
-          p = pathlib.Path("plugin/netbird.plg")
-          src = p.read_text()
-          entry = f"\n### {pv}\n\n- Update NetBird to {nv}.\n"
-          new = re.sub(
-              r"(<CHANGES>\s*<!\[CDATA\[\s*\n)",
-              lambda m: m.group(1) + entry,
-              src,
-              count=1,
+
+          tag = sys.argv[1]
+          MAX_ENTRIES = 12
+          FOOTER = "Older releases: https://github.com/netbirdio/netbird-unraid/releases"
+
+          notes_path = pathlib.Path("/tmp/release_body.md")
+          body = notes_path.read_text() if notes_path.exists() else ""
+          body = body.replace("\r\n", "\n").replace("\r", "\n").strip()
+          if not body:
+              body = "- Maintenance release."
+
+          # Demote any ATX headings in the body two levels so they render smaller
+          # than the "### <version>" heading we add below.
+          body = re.sub(
+              r"(?m)^(#{1,6})(?=\s)",
+              lambda m: "#" * min(len(m.group(1)) + 2, 6),
+              body,
           )
-          p.write_text(new)
+          new_entry = f"### {tag}\n\n{body}"
+
+          plg = pathlib.Path("plugin/netbird.plg")
+          src = plg.read_text()
+          m = re.search(
+              r"(<CHANGES>\s*<!\[CDATA\[\n)(.*?)(\n\]\]>\s*</CHANGES>)",
+              src,
+              re.S,
+          )
+          if not m:
+              raise SystemExit("Could not locate <CHANGES> CDATA block in netbird.plg")
+
+          inner = m.group(2)
+          # Drop any existing footer line; we re-add a single one at the bottom.
+          inner = re.sub(r"(?m)^Older releases:.*$", "", inner)
+          # Split the existing history into version blocks, newest first.
+          blocks = [b.strip("\n") for b in re.split(r"(?m)(?=^### )", inner) if b.strip()]
+          blocks = [new_entry] + blocks
+          blocks = blocks[:MAX_ENTRIES]
+
+          new_inner = "\n" + "\n\n".join(blocks) + "\n\n" + FOOTER + "\n"
+          new_src = src[: m.start()] + m.group(1) + new_inner + m.group(3) + src[m.end() :]
+          plg.write_text(new_src)
           PY
 
-          # Re-run build so dist/netbird.plg picks up the new CHANGES block.
-          ./scripts/build.sh >/dev/null
           echo "--- new CHANGES head ---"
-          sed -n '/<CHANGES>/,/<\/CHANGES>/p' plugin/netbird.plg | head -10
+          sed -n '/<CHANGES>/,/<\/CHANGES>/p' plugin/netbird.plg | head -20
 
-      - name: Stage plg + json for commit
-        if: steps.changed.outputs.skip != 'true'
-        run: |
-          # The finalized .plg in dist/ already has the new version + new
-          # package SHA256 substituted in. Copy it over the source one so
-          # users get accurate pluginURL metadata on update check.
-          cp dist/netbird.plg plugin/netbird.plg
+      - name: Rebuild so dist/.plg has the new CHANGES
+        env:
+          VERSION: ${{ steps.rel.outputs.tag }}
+        run: ./scripts/build.sh >/dev/null
 
-      - name: Commit + tag + push
-        if: steps.changed.outputs.skip != 'true'
+      - name: Commit built .plg to main
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          PV='${{ steps.build.outputs.plugin_version }}'
-          NV='${{ steps.nb.outputs.version }}'
+          # The finalized .plg in dist/ has the version + package SHA256 + new
+          # CHANGES substituted in. Copy it over the source so the pluginURL on
+          # main serves accurate update metadata.
+          cp dist/netbird.plg plugin/netbird.plg
 
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugin/netbird.plg
+          if git commit -m "release ${{ steps.rel.outputs.tag }}"; then
+              git push origin HEAD:main
+          else
+              echo "No .plg changes to commit."
+          fi
 
-          git add plugin/netbird.plg plugin/plugin.json
-          git commit -m "release ${PV}: NetBird ${NV}"
-          git tag "${PV}"
-          git push origin HEAD:main
-          git push origin "${PV}"
-
-      - name: Create GitHub Release
-        if: steps.changed.outputs.skip != 'true'
+      - name: Upload package to release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          PV='${{ steps.build.outputs.plugin_version }}'
-          NV='${{ steps.nb.outputs.version }}'
-          PKG='${{ steps.build.outputs.pkg_path }}'
-
-          gh release create "${PV}" "${PKG}" \
-              --title "${PV}" \
-              --notes "NetBird ${NV} · plugin ${PV}
-
-          Install URL:
-          \`https://raw.githubusercontent.com/${{ github.repository }}/main/plugin/netbird.plg\`"
+          PKG=$(ls dist/unraid-netbird-utils-*.txz | head -1)
+          gh release upload "${{ steps.rel.outputs.tag }}" "$PKG" \
+              --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/update-netbird.yml
+++ b/.github/workflows/update-netbird.yml
@@ -1,0 +1,132 @@
+name: Update NetBird
+
+# Daily check for a new upstream NetBird release. When one is found, bump the
+# pinned version + SHA256 and open a "chore: update NetBird to X" PR against main.
+# Merging that PR puts a single Maintenance line in the drafted changelog; it does
+# NOT release on its own — the maintainer publishes the draft when ready.
+#
+# Prereqs (one-time):
+#   - Repo Settings -> Actions -> "Read and write permissions" +
+#     "Allow GitHub Actions to create and approve pull requests".
+#   - A repo label named "chore" must exist.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      netbird_version:
+        description: 'NetBird version to pin (e.g. 0.71.3, or "latest")'
+        required: false
+        default: 'latest'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve NetBird version
+        id: nb
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          REQ='${{ inputs.netbird_version }}'
+          if [ -z "$REQ" ] || [ "$REQ" = "latest" ]; then
+              TAG=$(gh release view --repo netbirdio/netbird --json tagName --jq .tagName)
+          else
+              # Accept "0.71.3" or "v0.71.3"
+              TAG="${REQ#v}"
+              TAG="v${TAG}"
+          fi
+          VER="${TAG#v}"
+          ASSET="netbird_${VER}_linux_amd64.tar.gz"
+
+          # Pull the digest GitHub already stores for the asset.
+          DIGEST=$(gh release view "$TAG" --repo netbirdio/netbird \
+              --json assets --jq ".assets[] | select(.name == \"$ASSET\") | .digest")
+          if [ -z "$DIGEST" ]; then
+              echo "::error::Asset $ASSET not found in netbirdio/netbird@$TAG"
+              exit 1
+          fi
+          SHA256="${DIGEST#sha256:}"
+
+          # Defense in depth: download + verify locally so we don't trust the API alone.
+          URL="https://github.com/netbirdio/netbird/releases/download/${TAG}/${ASSET}"
+          curl -fsSL -o /tmp/nb.tgz "$URL"
+          ACTUAL=$(sha256sum /tmp/nb.tgz | awk '{print $1}')
+          if [ "$ACTUAL" != "$SHA256" ]; then
+              echo "::error::SHA256 mismatch: API=$SHA256 actual=$ACTUAL"
+              exit 1
+          fi
+          rm -f /tmp/nb.tgz
+
+          echo "version=$VER"   >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+
+      - name: Detect unchanged upstream
+        id: changed
+        run: |
+          CUR=$(sed -nE 's/.*<!ENTITY netbirdVer\s+"([^"]+)".*/\1/p' plugin/netbird.plg | head -1)
+          echo "current=$CUR" >> "$GITHUB_OUTPUT"
+          if [ "$CUR" = "${{ steps.nb.outputs.version }}" ]; then
+              echo "::notice::NetBird already pinned at $CUR."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update plugin/netbird.plg + plugin/plugin.json
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          NB_VER='${{ steps.nb.outputs.version }}'
+          NB_SHA='${{ steps.nb.outputs.sha256 }}'
+
+          sed -i -E 's|(<!ENTITY netbirdVer\s+")[^"]+(">)|\1'"$NB_VER"'\2|' plugin/netbird.plg
+          sed -i -E 's|(<!ENTITY netbirdSHA256\s+")[^"]+(">)|\1'"$NB_SHA"'\2|' plugin/netbird.plg
+
+          # plugin.json mirror (documentation only)
+          tmp=$(mktemp)
+          jq --arg v "$NB_VER" --arg s "$NB_SHA" \
+              '.netbirdVersion = $v | .netbirdSHA256 = $s' plugin/plugin.json > "$tmp"
+          mv "$tmp" plugin/plugin.json
+
+      - name: Open / update PR
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          NB_VER='${{ steps.nb.outputs.version }}'
+          BRANCH='automation/netbird-bump'
+          TITLE="chore: update NetBird to ${NB_VER}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add plugin/netbird.plg plugin/plugin.json
+          if git commit -m "$TITLE"; then
+              git push --force origin "$BRANCH"
+          else
+              echo "No changes to commit."
+              exit 0
+          fi
+
+          gh pr create \
+              --title "$TITLE" \
+              --body "Automated upstream bump: NetBird \`${NB_VER}\` (version + SHA256 verified against netbirdio/netbird)." \
+              --head "$BRANCH" \
+              --base main \
+              --label chore \
+          || gh pr edit "$BRANCH" --title "$TITLE"

--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -37,13 +37,6 @@
 <CHANGES>
 <![CDATA[
 
-
-
-
-
-
-
-
 ### 2026.05.27.1742
 
 - Update NetBird to 0.71.4.
@@ -69,6 +62,7 @@
 
 - Initial preview release. NetBird 0.71.2 running natively on Unraid as a system plugin.
 
+Older releases: https://github.com/netbirdio/netbird-unraid/releases
 ]]>
 </CHANGES>
 


### PR DESCRIPTION
## Summary

Replaces the old "auto-release on every NetBird bump" model with a **draft-then-publish** release pipeline driven by conventional-commit PR titles.

Merged PRs accumulate into a single auto-updated draft GitHub Release, categorized into **New Features / Bug Fixes / Maintenance**. The maintainer publishes the draft when ready; publishing is the only thing that cuts a release. On publish, the plugin is built, the categorized changelog is injected into the `.plg` `<CHANGES>` block (what Unraid shows in its update popup), the finalized `.plg` is committed back to `main`, and the `.txz` asset is uploaded to the release.

This fixes two problems with the previous flow: plugin-only changes had nowhere to appear in the changelog (every entry was an identical `Update NetBird to X` line), and releases shipped automatically with no maintainer control. Upstream NetBird bumps now arrive as a reviewable PR instead of an instant release.

## Changes

**New files**

- `.github/release-drafter.yml` — Release Drafter config. Categorizes merged PRs by label (`feat` → New Features, `fix` → Bug Fixes, `chore`/`refactor` → Maintenance), renders categories as bold sub-labels (so they nest under the version heading in Unraid's renderer), strips the conventional-commit prefix from each title, and excludes internal labels (`docs`, `test`, `ci`, `perf`, `translation`). Includes an autolabeler that labels PRs from their conventional-commit title.
- `.github/workflows/draft-release.yml` — On push to `main`, (re)drafts the release with a timestamp version (`YYYY.MM.DD.HHMM`). On PRs, autolabels from the title so categories work without manual labeling.
- `.github/workflows/update-netbird.yml` — Daily check (07:00 UTC) for a new upstream NetBird release. Verifies the asset SHA256 (API digest + local re-download), bumps the pinned version in `netbird.plg` + `plugin.json`, and opens a `chore: update NetBird to X` PR. Does not release on its own. Supports manual dispatch with an explicit version.
- `.github/workflows/pr-title.yml` — Optional gate validating PR titles follow Conventional Commits, so the autolabeler can sort each PR correctly.

**Rewritten**

- `.github/workflows/release.yml` — Now triggers on `release: published` (plus manual `workflow_dispatch` to rebuild a tag). Builds via `scripts/build.sh`, injects the published release body into the `.plg` `<CHANGES>` block (newest-first, headings demoted, trimmed to 12 version entries, single "Older releases" footer), commits the built `.plg` to `main`, and uploads the `.txz`.

**Edited**

- `plugin/netbird.plg` — Blank-line cleanup in the `<CHANGES>` block and the "Older releases" footer line.

## Required setup before merge

1. **Labels** — created (`feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `ci`, `perf`, `translation`).
2. **Repo Settings → Actions → Workflow permissions** — needs **Read and write permissions** + **Allow GitHub Actions to create and approve pull requests** enabled. Requires an org admin (maintainers can't set this). Without it, the `.plg` commit-back and the bump PRs fail.

## Notes

- Releases are **manual-publish by design** — merging a NetBird bump updates the draft but does not ship. The maintainer clicks Publish to cut a release.
- If a release's only merged PRs are excluded ones (all `docs`/`ci`/etc.), the injected changelog falls back to `- Maintenance release.` rather than a blank entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated GitHub Release management for plugin releases.
  * Automated NetBird version detection and updating workflow.
  * Pull request title validation against conventional commit standards.

* **Chores**
  * Updated NetBird to version 0.71.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->