### PR TITLE
chore: update NetBird to 0.73.0

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.72.4">
+<!ENTITY netbirdVer    "0.73.1">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "8ee7807d716ed088ab05976bc161838120730f9cf9fec794aacb5b51d904f1fc">
+<!ENTITY netbirdSHA256 "19015548fd9e7bae9d1865b542d26f34b70d977af309b9c278159f8d377aaac9">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.72.4",
-  "netbirdSHA256": "8ee7807d716ed088ab05976bc161838120730f9cf9fec794aacb5b51d904f1fc"
+  "netbirdVersion": "0.73.1",
+  "netbirdSHA256": "19015548fd9e7bae9d1865b542d26f34b70d977af309b9c278159f8d377aaac9"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.73.0` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the embedded NetBird upstream binary to **0.73.1**, updating the related package version metadata and verification checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->