### PR TITLE
fix: restart NetBird daemon on update so the dashboard shows the new version

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -171,10 +171,13 @@ NEOF
     echo "  wrote $NEC with include_interfaces=\"wt0\""
 fi
 
-# Start the daemon synchronously (waits for the socket), then reload nginx as
+# Restart the daemon synchronously (waits for the socket), then reload nginx as
 # soon as wt0 appears (so the WebGUI binds to the NetBird IP and is reachable
-# from other peers).
-/etc/rc.d/rc.netbird start
+# from other peers). "restart" (not "start") matters on upgrades: the old daemon
+# is still running the previous binary, so a plain "start" would no-op on it and
+# `netbird status` would keep reporting the old version until the next reboot.
+# stop is a safe no-op on a clean install where nothing is running yet.
+/etc/rc.d/rc.netbird restart
 (
     for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
         if ip -4 addr show wt0 >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

Relates to #15.

### Problem

After a plugin update the Dashboard keeps showing the old NetBird version until you reboot.

### Root cause

The install script drops the new binary in place and then runs `rc.netbird start`, but on an upgrade the old daemon is still running, so `start` no-ops and the old binary stays in memory. The Dashboard reads its version from `netbird status --json`, which reports whatever the running daemon is, hence the stale value. A reboot only fixes it because the array-start event hook runs `rc.netbird restart`.

### Fix

This switches the install step from `start` to `restart` so the upgrade actually swaps the daemon onto the new binary. `stop` is a no-op on a fresh install, and the stop path already waits for the old process to exit before starting, so there's no race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NetBird service startup during upgrades by ensuring the daemon is restarted rather than simply started, preventing compatibility issues with older running instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->