### PR TITLE
fix: render the dashboard widget as a grid tile so it aligns and can be moved

### DIFF
--- a/src/usr/local/emhttp/plugins/netbird/Netbird_dashboard.page
+++ b/src/usr/local/emhttp/plugins/netbird/Netbird_dashboard.page
@@ -1,39 +1,135 @@
-Menu="Dashboard"
-Title="NetBird"
-Icon="netbird.png"
-Type="php"
-Tabs="false"
+Cond="version_compare(parse_ini_file('/etc/unraid-version')['version'],'6.11.9','>')"
+Menu="Dashboard:0"
 ---
 <?php
+// Renders the NetBird widget on the Unraid Dashboard. The content must be
+// registered through $mytiles (as a <tbody> table fragment) rather than echoed
+// directly, otherwise the dashboard grid won't size it, align it, or let the
+// user drag it like a normal widget.
 try {
-$docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
-require_once "{$docroot}/plugins/netbird/include/common.php";
+    $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
+    require_once "{$docroot}/plugins/netbird/include/common.php";
 
-$running = Netbird\daemonRunning();
-$status  = Netbird\statusJson();
-$ip4     = $status['netbirdIp']   ?? '';
-$ip6     = $status['netbirdIpv6'] ?? '';
-$prof    = $status['profileName'] ?? '';
-$peers   = isset($status['peers']['details']) ? count($status['peers']['details']) : 0;
-$connPeers = (int) ($status['peers']['connected'] ?? 0);
-$mgmtOk  = !empty($status['management']['connected']);
-?>
-<div>
-    <span class="dashboard-tile-title">NetBird</span>
-    <?php if ($running && $mgmtOk): ?>
-        <span style="color:#2eaa2e;">Connected</span>
-        <?php if ($prof): ?> &middot; <?=htmlspecialchars($prof)?><?php endif; ?>
-        <?php if ($ip4): ?>  &middot; <code><?=htmlspecialchars($ip4)?></code><?php endif; ?>
-        <?php if ($ip6): ?>  &middot; <code><?=htmlspecialchars($ip6)?></code><?php endif; ?>
-        <?php if ($peers): ?> &middot; <?=$connPeers?>/<?=$peers?> peer<?=$peers === 1 ? '' : 's'?><?php endif; ?>
-    <?php elseif ($running): ?>
-        <span style="color:#d39e00;">Daemon running, not logged in</span>
-    <?php else: ?>
-        <span style="color:#c8331f;">Stopped</span>
-    <?php endif; ?>
-</div>
-<?php
+    $running   = Netbird\daemonRunning();
+    $status    = Netbird\statusJson();
+    $ip4       = $status['netbirdIp']   ?? '';
+    $ip6       = $status['netbirdIpv6'] ?? '';
+    $fqdn      = $status['fqdn']        ?? '';
+    $prof      = $status['profileName'] ?? '';
+    $mgmtOk    = !empty($status['management']['connected']);
+
+    $row = static fn (string $label, string $value): string =>
+        "<tr><td><span class='w26'>{$label}</span>{$value}</td></tr>" . PHP_EOL;
+
+    if ($running && $mgmtOk) {
+        $state = "<span style='color:#2eaa2e;'>Connected</span>";
+    } elseif ($running) {
+        $state = "<span style='color:#d39e00;'>Daemon running, not logged in</span>";
+    } else {
+        $state = "<span style='color:#c8331f;'>Stopped</span>";
+    }
+
+    $rows = $row('Status', $state);
+
+    if ($status) {
+        if ($running && $mgmtOk) {
+            // Peer breakdown by connection type (direct vs relayed).
+            $details = $status['peers']['details'] ?? [];
+            $peers   = (int) ($status['peers']['total'] ?? count($details));
+            $connPeers = (int) ($status['peers']['connected'] ?? 0);
+            $relayed = 0;
+            $direct  = 0;
+            foreach ($details as $p) {
+                if (($p['status'] ?? '') === 'Connected') {
+                    if (($p['connectionType'] ?? '') === 'Relayed') {
+                        $relayed++;
+                    } else {
+                        $direct++;
+                    }
+                }
+            }
+
+            if ($prof !== '') { $rows .= $row('Profile',  htmlspecialchars($prof)); }
+            if ($fqdn !== '') { $rows .= $row('DNS name', htmlspecialchars($fqdn)); }
+            if ($ip4  !== '') { $rows .= $row('IP',       "<code>" . htmlspecialchars($ip4) . "</code>"); }
+            if ($ip6  !== '') { $rows .= $row('IPv6',     "<code>" . htmlspecialchars($ip6) . "</code>"); }
+            if ($peers) {
+                $peerVal = "{$connPeers}/{$peers} · {$direct} direct, {$relayed} relayed";
+                $rows .= $row('Peers', $peerVal);
+            }
+
+            // Routed networks / exit node.
+            $nets = $status['networks'] ?? [];
+            if (!empty($nets)) {
+                $exit  = in_array('0.0.0.0/0', $nets, true) || in_array('::/0', $nets, true);
+                $count = count($nets);
+                $netVal = $count . ' route' . ($count === 1 ? '' : 's') . ($exit ? ' · exit node' : '');
+                $rows .= $row('Networks', $netVal);
+            }
+        }
+
+        // Version, with a hint when the running daemon is older than the
+        // installed binary (i.e. it hasn't been restarted onto the new version).
+        $dv = (string) ($status['daemonVersion'] ?? '');
+        $cv = (string) ($status['cliVersion'] ?? '');
+        if ($dv !== '') {
+            $verVal = htmlspecialchars($dv);
+            if ($cv !== '' && $cv !== $dv) {
+                $verVal .= " <span style='color:#d39e00;'>(restart pending: binary " . htmlspecialchars($cv) . ")</span>";
+            }
+            $rows .= $row('Version', $verVal);
+        }
+
+        // Surface a control-plane error if one is present.
+        $err = trim((string) ($status['management']['error'] ?? ''));
+        if ($err === '') {
+            $err = trim((string) ($status['signal']['error'] ?? ''));
+        }
+        if ($err !== '') {
+            $rows .= $row('Error', "<span style='color:#c8331f;'>" . htmlspecialchars($err) . "</span>");
+        }
+    }
+
+    $mytiles['netbird']['column2'] = <<<EOT
+        <tbody title="NetBird">
+        <tr>
+            <td>
+                <div class='tile-header' id='netbird-dashboard-card'>
+                    <div class='tile-header-left'>
+                        <img style="margin-right: 8px; width: 32px; height: 32px" src="/plugins/netbird/netbird.png" alt="NetBird">
+                        <div class='section'>
+                            <h3 class='tile-header-main' id='netbird-dashboard-title'>NetBird</h3>
+                        </div>
+                    </div>
+                    <div class='tile-header-right'>
+                        <div class='tile-header-right-controls'>
+                            <a id="netbird-settings-button" href="/Settings/Netbird" title="Settings"><i class="fa fa-fw fa-cog control"></i></a>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        {$rows}
+        </tbody>
+        EOT;
+
+    // Pre-7.2 WebGUIs lay out the tile header differently; move the title and
+    // settings cog into place the way the responsive (7.2+) theme does natively.
+    $isResponsiveWebgui = version_compare(parse_ini_file('/etc/unraid-version')['version'] ?? '', '7.2', '>=');
+    if (!$isResponsiveWebgui) {
+        echo <<<EOT
+            <script>
+                $(function() {
+                    $('#netbird-dashboard-title').replaceWith(function() {
+                        return $(this).text() + "<br>";
+                    });
+                    $('#netbird-settings-button').prependTo('#netbird-dashboard-card');
+                });
+            </script>
+            EOT;
+    }
 } catch (\Throwable $e) {
-    echo "<span class='dashboard-tile-title'>NetBird</span><span style='color:#c8331f;'>plugin error</span>";
+    $mytiles['netbird']['column2'] =
+        '<tbody title="NetBird"><tr><td>NetBird dashboard widget error.</td></tr></tbody>';
 }
 ?>


### PR DESCRIPTION
## Description

Fixes #14.

<img width="1072" height="454" alt="Screenshot From 2026-06-22 09-35-09" src="https://github.com/user-attachments/assets/64a4851b-d926-4ca2-ac8c-2d0e4c7991c1" />

The dashboard tile stretched full width and couldn't be dragged into the grid because the widget echoed a bare `<div>` instead of registering through Unraid's `$mytiles` API. Unraid only sizes and positions tiles that come in as table fragments, so a loose div falls outside the grid.

This registers the tile through `$mytiles['netbird']['column2']` as a `<tbody>` fragment with the standard `tile-header` markup, the same way the Tailscale plugin does it, which restores normal width, grid alignment, and drag-and-drop. The status logic is untouched; only the output wrapper moved. A `Cond` guard skips the tile on Unraid older than 6.12 (before the grid API), and a small script fixes up the title and cog on pre-7.2 layouts.

While here, the tile now shows Status plus, when connected, Profile, DNS name (the other ask in the issue), IP, IPv6, Peers (direct vs relayed), Networks (route count and exit-node flag), and Version. Version flags a pending restart when the running daemon is older than the installed binary, and an Error row shows only if NetBird reports a management or signal error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced NetBird dashboard with improved connection status display
  * Added detailed peer information showing direct vs relayed connections
  * Display of IPv4, IPv6, and DNS configuration details
  * Added exit node and routed network detection

* **Bug Fixes**
  * Improved error handling and messaging in dashboard widget

<!-- end of auto-generated comment: release notes by coderabbit.ai -->