### PR TITLE
chore: update NetBird to 0.73.2

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.73.1">
+<!ENTITY netbirdVer    "0.73.2">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "19015548fd9e7bae9d1865b542d26f34b70d977af309b9c278159f8d377aaac9">
+<!ENTITY netbirdSHA256 "d7e19ecd32608f83a944cf3cdbed231e6ad8aeb657d83d549eca8b29aa0c70a6">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.73.1",
-  "netbirdSHA256": "19015548fd9e7bae9d1865b542d26f34b70d977af309b9c278159f8d377aaac9"
+  "netbirdVersion": "0.73.2",
+  "netbirdSHA256": "d7e19ecd32608f83a944cf3cdbed231e6ad8aeb657d83d549eca8b29aa0c70a6"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.73.2` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NetBird plugin to version 0.73.2 with updated integrity verification checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->