### PR TITLE
fix: point the plugin support link to Issues instead of Discussions

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -30,7 +30,7 @@
   launch="&launch;"
   pluginURL="&pluginURL;"
   min="7.0.0"
-  support="https://github.com/&gitUser;/&gitRepo;/discussions"
+  support="https://github.com/&gitUser;/&gitRepo;/issues"
   project="https://github.com/&gitUser;/&gitRepo;"
 >
 


### PR DESCRIPTION
## Description

The plugin's `support` link pointed at the repo's Discussions tab, but we triage support there through Issues. This updates the `support` attribute in `netbird.plg` so the "Support" link Unraid shows for the plugin opens Issues instead.

```
- support="https://github.com/&gitUser;/&gitRepo;/discussions"
+ support="https://github.com/&gitUser;/&gitRepo;/issues"
```

One line, no behavior change. The `support` attribute is part of the `.plg` template and the build only substitutes the version and package hash, so the change ships through to the released `.plg` as-is.