### PR TITLE
chore: update NetBird to 0.74.0

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.73.2">
+<!ENTITY netbirdVer    "0.74.0">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "d7e19ecd32608f83a944cf3cdbed231e6ad8aeb657d83d549eca8b29aa0c70a6">
+<!ENTITY netbirdSHA256 "3eb409003d891e4e4867f8157103dc388b92d8ac7ec7d26b5596a234557b307e">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.73.2",
-  "netbirdSHA256": "d7e19ecd32608f83a944cf3cdbed231e6ad8aeb657d83d549eca8b29aa0c70a6"
+  "netbirdVersion": "0.74.0",
+  "netbirdSHA256": "3eb409003d891e4e4867f8157103dc388b92d8ac7ec7d26b5596a234557b307e"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.74.0` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the NetBird plugin to reference version 0.74.0.
  * Refreshed the associated download details and checksum to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->