### PR TITLE
chore: update NetBird to 0.74.1

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.74.0">
+<!ENTITY netbirdVer    "0.74.1">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "3eb409003d891e4e4867f8157103dc388b92d8ac7ec7d26b5596a234557b307e">
+<!ENTITY netbirdSHA256 "8d677ae87113d297d189818c80928a5c90e93c2b132a212e568af5070192e6a2">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.74.0",
-  "netbirdSHA256": "3eb409003d891e4e4867f8157103dc388b92d8ac7ec7d26b5596a234557b307e"
+  "netbirdVersion": "0.74.1",
+  "netbirdSHA256": "8d677ae87113d297d189818c80928a5c90e93c2b132a212e568af5070192e6a2"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.74.1` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled NetBird package to version **0.74.1**, incorporating upstream improvements and fixes.
  * Refreshed the associated download verification details (including the release artifact details) to match the updated NetBird release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->