### PR TITLE
chore: update NetBird to 0.74.3

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.74.2">
+<!ENTITY netbirdVer    "0.74.3">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "c29f83efbc54c082323857ef99853971703e6230d3d7de9e045fc63cc4ebe135">
+<!ENTITY netbirdSHA256 "6444b48bebaacce8af0baafdf2907232a94a54d591566dd633a023650cf8daa3">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.74.2",
-  "netbirdSHA256": "c29f83efbc54c082323857ef99853971703e6230d3d7de9e045fc63cc4ebe135"
+  "netbirdVersion": "0.74.3",
+  "netbirdSHA256": "6444b48bebaacce8af0baafdf2907232a94a54d591566dd633a023650cf8daa3"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.74.3` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled NetBird plugin to version 0.74.3.
  * Refreshed the download checksum to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->