### PR TITLE
chore: update NetBird to 0.74.5

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.74.4">
+<!ENTITY netbirdVer    "0.74.5">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "b854710409e7de79071642e2c328b181d4db7b9c90c298ee32b6e3b5d9ebd36f">
+<!ENTITY netbirdSHA256 "87059638c0152a67ea293d4973d29589e7a3cf9096bd110e385ceb7a68dbe724">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.74.4",
-  "netbirdSHA256": "b854710409e7de79071642e2c328b181d4db7b9c90c298ee32b6e3b5d9ebd36f"
+  "netbirdVersion": "0.74.5",
+  "netbirdSHA256": "87059638c0152a67ea293d4973d29589e7a3cf9096bd110e385ceb7a68dbe724"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.74.5` (version + SHA256 verified against netbirdio/netbird).