### PR TITLE
fix: avoid status and settings page delays when NetBird is disabled

### DIFF
--- a/src/usr/local/emhttp/plugins/netbird/Netbird-1-Settings.page
+++ b/src/usr/local/emhttp/plugins/netbird/Netbird-1-Settings.page
@@ -18,8 +18,20 @@ $enableSsh     = $cfg['ENABLE_SSH']       ?? '0';
 $manageDns     = $cfg['MANAGE_DNS']       ?? '1';
 $logLevel      = $cfg['LOG_LEVEL']        ?? 'info';
 
-$profiles      = Netbird\listProfiles();
-$activeProf    = Netbird\activeProfile();
+$enableCfg     = strtolower(trim((string) $enabled));
+$serviceEnabled = !in_array($enableCfg, ['0', 'false'], true);
+$daemonReady   = $serviceEnabled && Netbird\daemonRunning() && file_exists('/var/run/netbird.sock');
+$profiles      = $daemonReady ? Netbird\listProfiles() : [];
+if (!$profiles) {
+    $profiles = Netbird\savedProfiles();
+}
+$activeProf = '';
+foreach ($profiles as $profile) {
+    if ($profile['active']) {
+        $activeProf = $profile['name'];
+        break;
+    }
+}
 
 // Which profile's credentials is the form editing? ?nbprofile= wins, then the
 // active profile, then "default" (NetBird's built-in profile).
@@ -28,7 +40,19 @@ if (!Netbird\validProfileName($editProf)) {
     $editProf = '';
 }
 if ($editProf === '') {
-    $editProf = $activeProf !== '' ? $activeProf : 'default';
+    $editProf = $activeProf;
+    if ($editProf === '' && $profiles) {
+        $editProf = $profiles[0]['name'];
+        foreach ($profiles as $profile) {
+            if ($profile['name'] === 'default') {
+                $editProf = 'default';
+                break;
+            }
+        }
+    }
+    if ($editProf === '') {
+        $editProf = 'default';
+    }
 }
 
 // Credentials are stored per profile (profiles/<name>.cfg), not globally.
@@ -61,14 +85,20 @@ $preSharedKey  = $creds['PRESHARED_KEY'];
                 </option>
             <?php endforeach; ?>
         </select>
-        <input type="button" value="_(Switch)_" onclick="nbProfile('select', $('#nb-profile-select').val())">
-        <input type="button" value="_(Delete)_" onclick="nbProfileDelete()">
+        <?php if ($daemonReady): ?>
+            <input type="button" value="_(Switch)_" onclick="nbProfile('select', $('#nb-profile-select').val())">
+            <input type="button" value="_(Delete)_" onclick="nbProfileDelete()">
+        <?php endif; ?>
     <?php else: ?>
-        <span class="nb-profile-empty">No profiles found yet — editing <code><?=htmlspecialchars($editProf)?></code>. Start the daemon and add one below.</span>
+        <span class="nb-profile-empty">No saved profiles yet — editing <code><?=htmlspecialchars($editProf)?></code>.</span>
     <?php endif; ?>
-    &nbsp;&nbsp;
-    <input type="text" id="nb-profile-new" placeholder="new-profile-name" maxlength="32">
-    <input type="button" value="_(+ Add)_" onclick="nbProfileAdd()">
+    <?php if ($daemonReady): ?>
+        &nbsp;&nbsp;
+        <input type="text" id="nb-profile-new" placeholder="new-profile-name" maxlength="32">
+        <input type="button" value="_(+ Add)_" onclick="nbProfileAdd()">
+    <?php else: ?>
+        <span class="nb-profile-empty">Profile controls are available while NetBird is running.</span>
+    <?php endif; ?>
 </div>
 
 <blockquote class="inline_help">

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -51,7 +51,7 @@ function nb(array $args, int $timeoutSec = 0): array
  */
 function statusJson(): ?array
 {
-    [$rc, $out] = nb(['status', '--json']);
+    [$rc, $out] = nb(['status', '--json'], 3);
     if ($rc !== 0 || $out === '') {
         return null;
     }
@@ -130,7 +130,7 @@ function readApplyResult(): ?array
  */
 function listProfiles(): array
 {
-    [$rc, $out] = nb(['profile', 'list']);
+    [$rc, $out] = nb(['profile', 'list'], 3);
     if ($rc !== 0) {
         return [];
     }
@@ -149,6 +149,27 @@ function listProfiles(): array
             ];
         }
     }
+    return $profiles;
+}
+
+/**
+ * List profiles with credentials saved by the plugin without contacting the
+ * daemon. This keeps the Settings page usable while NetBird is disabled.
+ *
+ * @return array<int, array{name:string, active:bool}>
+ */
+function savedProfiles(): array
+{
+    $profiles = [];
+    foreach (glob(PROFILE_DIR . '/*.cfg') ?: [] as $path) {
+        $name = pathinfo($path, PATHINFO_FILENAME);
+        if (validProfileName($name)) {
+            $profiles[] = ['name' => $name, 'active' => false];
+        }
+    }
+    usort($profiles, static function (array $a, array $b): int {
+        return strcasecmp($a['name'], $b['name']);
+    });
     return $profiles;
 }
 

--- a/src/usr/local/emhttp/plugins/netbird/include/status_view.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/status_view.php
@@ -3,11 +3,15 @@ try {
 $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
 require_once "{$docroot}/plugins/netbird/include/common.php";
 
-$running = Netbird\daemonRunning();
-$status  = Netbird\statusJson();
+$cfg       = Netbird\readCfg();
+$enableCfg = strtolower(trim((string) ($cfg['ENABLE_NETBIRD'] ?? '0')));
+$enabled   = !in_array($enableCfg, ['0', 'false'], true);
+$running   = Netbird\daemonRunning();
+$daemonReady = $enabled && $running && file_exists('/var/run/netbird.sock');
+$status    = $daemonReady ? Netbird\statusJson() : null;
 
 // Whether the plugin lets NetBird manage host DNS (MANAGE_DNS, default on).
-$manageDns = (Netbird\readCfg()['MANAGE_DNS'] ?? '1') === '1';
+$manageDns = ($cfg['MANAGE_DNS'] ?? '1') === '1';
 
 // The host's live resolver, so issue #2 ("NetBird took over my DNS") is visible
 // at a glance: when management is on, NetBird rewrites this to point at its own
@@ -19,8 +23,8 @@ if ($resolvRaw !== false && preg_match_all('/^\s*nameserver\s+(\S+)/mi', $resolv
 }
 
 $rawStatus = '';
-if (!$status) {
-    [$rc, $out] = Netbird\nb(['status']);
+if ($daemonReady && !$status) {
+    [$rc, $out] = Netbird\nb(['status'], 3);
     $rawStatus  = $out;
 }
 ?>


### PR DESCRIPTION
# Description

Follow-up to #27, which addressed #25.

Disabling NetBird stops the daemon, but the status page still ran `netbird status` twice and the Settings tab ran `netbird profile list` twice. Those calls waited for the missing daemon socket to time out, making `/Settings/Netbird` appear stuck for around 20 seconds.

## Changes

- Skip status and profile CLI calls when NetBird is disabled, stopped, or has no daemon socket.
- Load saved profile settings directly from the plugin config while the daemon is offline.
- Hide profile actions that require a running daemon.
- Add a three-second timeout to status and profile-list calls so an unresponsive daemon cannot block the WebGUI indefinitely.

## Testing

Tested on a live Unraid 7.3.2 server with NetBird 0.74.5:

- Reproduced the original stopped-daemon page load at 20,051 ms.
- Retested with the daemon stopped: status loaded in 40 ms and Settings in 44 ms.
- Retested with `ENABLE_NETBIRD=0`: status loaded in 53 ms and Settings in 14 ms.
- Confirmed saved profile settings remain visible while NetBird is offline.
- Re-enabled NetBird and confirmed it reconnected with the same profile and address.
- Confirmed config, profile, resolver, and binary hashes were unchanged.
- Ran PHP syntax checks on all plugin pages and helpers, plus `git diff --check` and package-layout validation.