### PR TITLE
chore: update NetBird to 0.75.0

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.74.7">
+<!ENTITY netbirdVer    "0.75.0">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "ff46fa7d9e5b07b6ad8fa731be2ac11193cec29dc139702901b00ba5763ca34a">
+<!ENTITY netbirdSHA256 "166438a7bbf19354c65128432140a26b7663945affaf8700c388113280e2d202">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.74.7",
-  "netbirdSHA256": "ff46fa7d9e5b07b6ad8fa731be2ac11193cec29dc139702901b00ba5763ca34a"
+  "netbirdVersion": "0.75.0",
+  "netbirdSHA256": "166438a7bbf19354c65128432140a26b7663945affaf8700c388113280e2d202"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.75.0` (version + SHA256 verified against netbirdio/netbird).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird-unraid/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787438952&installation_model_id=427504&pr_number=32&repository=netbirdio%2Fnetbird-unraid&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird-unraid%2Fpull%2F32&signature=af36f18a332ad10a8148c77958d060ef059a6722929638b69e1f7e878b6d13b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the bundled NetBird version to 0.75.0.
  * Refreshed the download metadata and checksum to match the new NetBird release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->