### PR TITLE
chore: update NetBird to 0.75.1

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.75.0">
+<!ENTITY netbirdVer    "0.75.1">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "166438a7bbf19354c65128432140a26b7663945affaf8700c388113280e2d202">
+<!ENTITY netbirdSHA256 "fe42d049a2d019bc55e787b423cd542edbd0765098002b4ab5b5fe19086a3406">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.75.0",
-  "netbirdSHA256": "166438a7bbf19354c65128432140a26b7663945affaf8700c388113280e2d202"
+  "netbirdVersion": "0.75.1",
+  "netbirdSHA256": "fe42d049a2d019bc55e787b423cd542edbd0765098002b4ab5b5fe19086a3406"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.75.1` (version + SHA256 verified against netbirdio/netbird).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/netbird-unraid/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787843835&installation_model_id=427504&pr_number=33&repository=netbirdio%2Fnetbird-unraid&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fnetbird-unraid%2Fpull%2F33&signature=e5f252f2d6c91cc75d4376de787bc81ef7a1a562f771e4abc786e08f46551112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the NetBird plugin to version 0.75.1.
  * Updated the download package and checksum to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->