### PR TITLE
chore: update NetBird to 0.76.1

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.76.0">
+<!ENTITY netbirdVer    "0.76.1">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "cb4097121d5247890e42b4e211c4965fa8b06ac00b879bfe4abb73af4c28cbd3">
+<!ENTITY netbirdSHA256 "8a965dc7ffa0426de7f95d713f953472c4036912b7011272f01d118a3e8f6233">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.76.0",
-  "netbirdSHA256": "cb4097121d5247890e42b4e211c4965fa8b06ac00b879bfe4abb73af4c28cbd3"
+  "netbirdVersion": "0.76.1",
+  "netbirdSHA256": "8a965dc7ffa0426de7f95d713f953472c4036912b7011272f01d118a3e8f6233"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.76.1` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled NetBird version to 0.76.1.
  * Refreshed the package integrity verification for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->