### PR TITLE
feat: use the daemon JSON gateway instead of scraping CLI output

### DIFF
--- a/src/usr/local/emhttp/plugins/netbird/Netbird-1-Settings.page
+++ b/src/usr/local/emhttp/plugins/netbird/Netbird-1-Settings.page
@@ -39,6 +39,16 @@ $editProf = (string) ($_GET['nbprofile'] ?? '');
 if (!Netbird\validProfileName($editProf)) {
     $editProf = '';
 }
+// A stale ?nbprofile= must not survive its profile: after a deletion the URL
+// still carries the old name, and rendering it leaves the form stuck "editing"
+// a profile that no longer exists. Only accept names present in the list;
+// anything else falls through to the active profile below. When the list is
+// empty (daemon down, nothing saved) keep the requested name so a fresh
+// install can still be pointed at a profile to pre-stage.
+if ($editProf !== '' && $profiles
+    && !in_array($editProf, array_column($profiles, 'name'), true)) {
+    $editProf = '';
+}
 if ($editProf === '') {
     $editProf = $activeProf;
     if ($editProf === '' && $profiles) {

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -163,7 +163,19 @@ switch ($action) {
         // profile-select case for the full picture).
         $active = Netbird\activeProfile();
         if ($active !== '') {
-            Netbird\nb(['profile', 'select', $active], 15);
+            [$rcSel, $outSel] = Netbird\nb(['profile', 'select', $active], 15);
+            // A failed select leaves the CLI's active-profile state possibly
+            // pointing at another profile; running `up` with $active's
+            // credentials anyway could apply them to the wrong profile.
+            if ($rcSel !== 0) {
+                Netbird\nbUnlock($lock);
+                echo json_encode([
+                    'type'    => 'error',
+                    'title'   => 'Profile select failed',
+                    'message' => $outSel ?: "Could not select profile '$active'.",
+                ]);
+                break;
+            }
         }
         // Refuse to connect a profile that was never registered (no stored key) —
         // `up` would otherwise drop into interactive SSO login, which we don't use.

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -157,11 +157,13 @@ switch ($action) {
             }
         }
         // Bring up the currently-active profile using its own stored credentials.
+        // Deliberately CLI, not the gateway's SwitchProfile RPC: the CLI also
+        // records the switch in its own per-user active-profile state, which the
+        // following CLI `up` reads to decide which profile to connect (see the
+        // profile-select case for the full picture).
         $active = Netbird\activeProfile();
         if ($active !== '') {
-            nb_api_or_cli('SwitchProfile',
-                ['profileName' => $active, 'username' => Netbird\apiUsername()],
-                ['profile', 'select', $active]);
+            Netbird\nb(['profile', 'select', $active], 15);
         }
         // Refuse to connect a profile that was never registered (no stored key) —
         // `up` would otherwise drop into interactive SSO login, which we don't use.
@@ -289,10 +291,14 @@ switch ($action) {
             ]);
             break;
         }
-        [$okSel, $outSel] = nb_api_or_cli('SwitchProfile',
-            ['profileName' => $name, 'username' => Netbird\apiUsername()],
-            ['profile', 'select', $name], 15);
-        if (!$okSel) {
+        // Deliberately CLI, not the gateway's SwitchProfile RPC. `netbird
+        // profile select` does more than the RPC: it records the switch in the
+        // CLI's own per-user active-profile state and runs `down` first when
+        // connected. The follow-up CLI `up` resolves its target profile from
+        // that CLI-side state, so a daemon-only switch would leave `up`
+        // reconnecting the PREVIOUS profile with this profile's credentials.
+        [$rcSel, $outSel] = Netbird\nb(['profile', 'select', $name], 15);
+        if ($rcSel !== 0) {
             Netbird\nbUnlock($lock);
             echo json_encode([
                 'type'    => 'error',

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -200,7 +200,7 @@ switch ($action) {
         echo json_encode([
             'type'    => $ok ? 'success' : 'error',
             'title'   => $ok ? 'Disconnected' : 'NetBird down failed',
-            'message' => $out ?: 'NetBird disconnected.',
+            'message' => $out ?: ($ok ? 'NetBird disconnected.' : 'netbird down returned an error.'),
         ]);
         break;
 
@@ -241,7 +241,7 @@ switch ($action) {
         echo json_encode([
             'type'    => $ok ? 'success' : 'error',
             'title'   => $ok ? 'Profile added' : 'Add failed',
-            'message' => $out ?: "Profile '$name' added.",
+            'message' => $out ?: ($ok ? "Profile '$name' added." : 'profile add returned an error.'),
             'profile' => $ok ? $name : null,
         ]);
         break;
@@ -265,7 +265,7 @@ switch ($action) {
         echo json_encode([
             'type'    => $ok ? 'success' : 'error',
             'title'   => $ok ? 'Profile removed' : 'Remove failed',
-            'message' => $out ?: "Profile '$name' removed.",
+            'message' => $out ?: ($ok ? "Profile '$name' removed." : 'profile remove returned an error.'),
         ]);
         break;
 

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -240,10 +240,27 @@ switch ($action) {
             Netbird\writeProfileCfg($name, []);
         }
         Netbird\nbUnlock($lock);
+        $msg = $out ?: ($ok ? "Profile '$name' added." : 'profile add returned an error.');
+        // NetBird allows duplicate display names, and the CLI warns right after
+        // an add when the name is already taken — the gateway path must surface
+        // that too, since the plugin keys credential files and later
+        // select/remove requests by display name. $out is '' only on gateway
+        // success; on the CLI fallback its own output already carries the
+        // warning.
+        if ($ok && $out === '') {
+            $dups = count(array_filter(
+                Netbird\listProfiles(),
+                static fn (array $p): bool => $p['name'] === $name
+            ));
+            if ($dups > 1) {
+                $msg .= "\nWarning: " . ($dups - 1)
+                     . " other profile(s) already use this name; operations by name may be ambiguous.";
+            }
+        }
         echo json_encode([
             'type'    => $ok ? 'success' : 'error',
             'title'   => $ok ? 'Profile added' : 'Add failed',
-            'message' => $out ?: ($ok ? "Profile '$name' added." : 'profile add returned an error.'),
+            'message' => $msg,
             'profile' => $ok ? $name : null,
         ]);
         break;

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -52,6 +52,30 @@ function nb_profile_unconfigured(string $name): bool
 }
 
 /**
+ * Run a daemon operation through the JSON gateway when available, falling
+ * back to the CLI when the gateway can't be reached. Application-level
+ * errors from the gateway are surfaced as-is (no CLI retry — the daemon
+ * already answered). Returns [ok, message]; message is the gateway error
+ * text or the raw CLI output ('' on gateway success).
+ *
+ * @param array<string,mixed> $body
+ * @param string[] $cliArgs
+ * @return array{0:bool,1:string}
+ */
+function nb_api_or_cli(string $method, array $body, array $cliArgs, int $timeoutSec = 0): array
+{
+    $res = Netbird\apiCall($method, $body, $timeoutSec > 0 ? $timeoutSec : 10);
+    if ($res['ok']) {
+        return [true, ''];
+    }
+    if ($res['reachable']) {
+        return [false, $res['error']];
+    }
+    [$rc, $out] = Netbird\nb($cliArgs, $timeoutSec);
+    return [$rc === 0, $out];
+}
+
+/**
  * Acquire the apply lock, or emit a "busy" JSON response and return false.
  * Serializes daemon-mutating actions with each other and with apply.sh so
  * concurrent ops don't cancel each other.
@@ -132,7 +156,9 @@ switch ($action) {
         // Bring up the currently-active profile using its own stored credentials.
         $active = Netbird\activeProfile();
         if ($active !== '') {
-            Netbird\nb(['profile', 'select', $active]);
+            nb_api_or_cli('SwitchProfile',
+                ['profileName' => $active, 'username' => Netbird\apiUsername()],
+                ['profile', 'select', $active]);
         }
         // Refuse to connect a profile that was never registered (no stored key) —
         // `up` would otherwise drop into interactive SSO login, which we don't use.
@@ -150,6 +176,10 @@ switch ($action) {
         // Reconnect uses the profile's stored identity; no setup key needed here
         // (a key is only required to register, which happens on save). Bounded so
         // a failing reconnect's retry/backoff can't hang the request.
+        // Deliberately CLI (not the JSON gateway): `up` folds the credential
+        // flags into the profile config and drives login/registration; the
+        // gateway's UpRequest only takes a profile name, so it can't replace
+        // this call without reimplementing SetConfig+Login here.
         [$rc, $out] = Netbird\nb(nb_up_args($creds), 90);
         Netbird\nbUnlock($lock);
         echo json_encode([
@@ -162,11 +192,11 @@ switch ($action) {
     case 'down':
         $lock = nb_lock_or_busy();
         if ($lock === false) { break; }
-        [$rc, $out] = Netbird\nb(['down']);
+        [$ok, $out] = nb_api_or_cli('Down', [], ['down'], 30);
         Netbird\nbUnlock($lock);
         echo json_encode([
-            'type'    => $rc === 0 ? 'success' : 'error',
-            'title'   => $rc === 0 ? 'Disconnected' : 'NetBird down failed',
+            'type'    => $ok ? 'success' : 'error',
+            'title'   => $ok ? 'Disconnected' : 'NetBird down failed',
             'message' => $out ?: 'NetBird disconnected.',
         ]);
         break;
@@ -196,18 +226,20 @@ switch ($action) {
         }
         $lock = nb_lock_or_busy();
         if ($lock === false) { break; }
-        [$rc, $out] = Netbird\nb(['profile', 'add', $name]);
-        if ($rc === 0) {
+        [$ok, $out] = nb_api_or_cli('AddProfile',
+            ['username' => Netbird\apiUsername(), 'profileName' => $name],
+            ['profile', 'add', $name], 15);
+        if ($ok) {
             // Seed an empty credential cfg so the new profile starts blank
             // rather than appearing to inherit another profile's settings.
             Netbird\writeProfileCfg($name, []);
         }
         Netbird\nbUnlock($lock);
         echo json_encode([
-            'type'    => $rc === 0 ? 'success' : 'error',
-            'title'   => $rc === 0 ? 'Profile added' : 'Add failed',
+            'type'    => $ok ? 'success' : 'error',
+            'title'   => $ok ? 'Profile added' : 'Add failed',
             'message' => $out ?: "Profile '$name' added.",
-            'profile' => $rc === 0 ? $name : null,
+            'profile' => $ok ? $name : null,
         ]);
         break;
 
@@ -220,14 +252,16 @@ switch ($action) {
         }
         $lock = nb_lock_or_busy();
         if ($lock === false) { break; }
-        [$rc, $out] = Netbird\nb(['profile', 'remove', $name]);
-        if ($rc === 0) {
+        [$ok, $out] = nb_api_or_cli('RemoveProfile',
+            ['username' => Netbird\apiUsername(), 'profileName' => $name],
+            ['profile', 'remove', $name], 15);
+        if ($ok) {
             Netbird\deleteProfileCfg($name);
         }
         Netbird\nbUnlock($lock);
         echo json_encode([
-            'type'    => $rc === 0 ? 'success' : 'error',
-            'title'   => $rc === 0 ? 'Profile removed' : 'Remove failed',
+            'type'    => $ok ? 'success' : 'error',
+            'title'   => $ok ? 'Profile removed' : 'Remove failed',
             'message' => $out ?: "Profile '$name' removed.",
         ]);
         break;
@@ -252,8 +286,10 @@ switch ($action) {
             ]);
             break;
         }
-        [$rcSel, $outSel] = Netbird\nb(['profile', 'select', $name]);
-        if ($rcSel !== 0) {
+        [$okSel, $outSel] = nb_api_or_cli('SwitchProfile',
+            ['profileName' => $name, 'username' => Netbird\apiUsername()],
+            ['profile', 'select', $name], 15);
+        if (!$okSel) {
             Netbird\nbUnlock($lock);
             echo json_encode([
                 'type'    => 'error',

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -64,7 +64,10 @@ function nb_profile_unconfigured(string $name): bool
  */
 function nb_api_or_cli(string $method, array $body, array $cliArgs, int $timeoutSec = 0): array
 {
-    $res = Netbird\apiCall($method, $body, $timeoutSec > 0 ? $timeoutSec : 10);
+    // Normalize once so the CLI fallback is bounded by the same effective
+    // timeout as the gateway attempt — nb() runs unbounded when passed 0.
+    $timeoutSec = $timeoutSec > 0 ? $timeoutSec : 10;
+    $res = Netbird\apiCall($method, $body, $timeoutSec);
     if ($res['ok']) {
         return [true, ''];
     }

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -289,6 +289,20 @@ function mapGatewayStatus(array $resp, string $profileName): array
 }
 
 /**
+ * Version of the installed netbird binary (`netbird version`, purely local —
+ * no daemon round-trip), or '' if unknown. Cached for the request.
+ */
+function cliVersion(): string
+{
+    static $ver = null;
+    if ($ver === null) {
+        [$rc, $out] = nb(['version'], 3);
+        $ver = $rc === 0 ? trim(explode("\n", $out)[0]) : '';
+    }
+    return $ver;
+}
+
+/**
  * Read JSON status. Returns null if daemon unreachable or output isn't JSON.
  * Prefers the JSON gateway; falls back to CLI `status --json` (covers daemons
  * started without --enable-json-socket, e.g. across a plugin upgrade that
@@ -305,7 +319,13 @@ function statusJson(): ?array
         if ($ap['ok']) {
             $profile = (string) ($ap['data']['profileName'] ?? '');
         }
-        return mapGatewayStatus($res['data'], $profile);
+        $mapped = mapGatewayStatus($res['data'], $profile);
+        // `status --json` reports the invoking binary's version as cliVersion;
+        // the gateway response has no equivalent, so ask the binary directly.
+        // The dashboard compares it against daemonVersion for its
+        // "restart pending" hint after a plugin upgrade.
+        $mapped['cliVersion'] = cliVersion();
+        return $mapped;
     }
 
     [$rc, $out] = nb(['status', '--json'], 3);

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -44,13 +44,260 @@ function nb(array $args, int $timeoutSec = 0): array
     return [$rc, implode("\n", $out)];
 }
 
+// ---------------------------------------------------------------------------
+// Daemon HTTP/JSON gateway (NetBird >= 0.75, daemon started with
+// --enable-json-socket by rc.netbird). Exposes the daemon gRPC API as
+// POST /daemon.DaemonService/<Method> with protobuf-JSON bodies over a
+// root-only unix socket — structured data without exec()'ing the CLI.
+// ---------------------------------------------------------------------------
+
+const HTTP_SOCK = '/var/run/netbird-http.sock';
+
+/**
+ * True when the daemon's JSON gateway socket is present and usable.
+ */
+function apiAvailable(): bool
+{
+    return file_exists(HTTP_SOCK) && function_exists('curl_init');
+}
+
+/**
+ * POST to the daemon's JSON gateway.
+ *
+ * Returns:
+ *   ok        — call succeeded (HTTP 200, valid JSON body)
+ *   data      — decoded response on success, null otherwise
+ *   error     — human-readable error text on failure
+ *   reachable — false only when the gateway itself couldn't be reached
+ *               (socket missing / connect failure): callers should fall back
+ *               to the CLI. True for application-level errors, which must be
+ *               surfaced, not silently retried through the CLI.
+ *
+ * @param array<string,mixed> $body
+ * @return array{ok:bool, data:?array, error:string, reachable:bool}
+ */
+function apiCall(string $method, array $body = [], int $timeoutSec = 10): array
+{
+    if (!apiAvailable()) {
+        return ['ok' => false, 'data' => null, 'error' => 'JSON gateway socket not available', 'reachable' => false];
+    }
+    $ch = curl_init('http://localhost/daemon.DaemonService/' . $method);
+    curl_setopt_array($ch, [
+        CURLOPT_UNIX_SOCKET_PATH => HTTP_SOCK,
+        CURLOPT_POST             => true,
+        CURLOPT_POSTFIELDS       => json_encode((object) $body),
+        CURLOPT_HTTPHEADER       => ['Content-Type: application/json'],
+        CURLOPT_RETURNTRANSFER   => true,
+        CURLOPT_TIMEOUT          => $timeoutSec,
+    ]);
+    $raw   = curl_exec($ch);
+    $errno = curl_errno($ch);
+    $http  = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    if ($raw === false) {
+        return ['ok' => false, 'data' => null, 'error' => "gateway request failed (curl errno $errno)", 'reachable' => false];
+    }
+    $decoded = json_decode((string) $raw, true);
+    if ($http !== 200) {
+        // grpc-gateway maps gRPC errors to {code, message} plus an HTTP status.
+        $msg = is_array($decoded) && !empty($decoded['message']) ? (string) $decoded['message'] : "HTTP $http";
+        return ['ok' => false, 'data' => null, 'error' => $msg, 'reachable' => true];
+    }
+    if (!is_array($decoded)) {
+        return ['ok' => false, 'data' => null, 'error' => 'gateway returned invalid JSON', 'reachable' => true];
+    }
+    return ['ok' => true, 'data' => $decoded, 'error' => '', 'reachable' => true];
+}
+
+/**
+ * OS username the daemon scopes profile operations to. The web UI runs as
+ * root on Unraid, same as the CLI, so profiles line up between the two.
+ */
+function apiUsername(): string
+{
+    if (function_exists('posix_geteuid') && function_exists('posix_getpwuid')) {
+        $pw = @posix_getpwuid(posix_geteuid());
+        if (is_array($pw) && !empty($pw['name'])) {
+            return $pw['name'];
+        }
+    }
+    return 'root';
+}
+
+/**
+ * First present key wins. Shields the gateway mapping from protojson json_name
+ * ambiguity on all-caps proto fields (IP/URL/URI keep their casing today, but
+ * a regenerated gateway could camel-case them).
+ *
+ * @param array<string,mixed> $a
+ * @param string[] $keys
+ */
+function pbGet(array $a, array $keys, mixed $default = null): mixed
+{
+    foreach ($keys as $k) {
+        if (array_key_exists($k, $a)) {
+            return $a[$k];
+        }
+    }
+    return $default;
+}
+
+/**
+ * protobuf-JSON Duration ("0.0125s") → nanoseconds, the unit the CLI's
+ * status --json uses and formatLatency() expects.
+ */
+function pbDurationNs(mixed $dur): int
+{
+    if (is_string($dur) && preg_match('/^([0-9]*\.?[0-9]+)s$/', $dur, $m)) {
+        return (int) round(((float) $m[1]) * 1_000_000_000);
+    }
+    return 0;
+}
+
+/**
+ * protobuf-JSON Timestamp → value relativeTime() treats as unknown when the
+ * daemon reported a zero time (protojson encodes it as the Unix epoch).
+ */
+function pbTimestamp(?string $ts): ?string
+{
+    if (!$ts || str_starts_with($ts, '1970-01-01') || str_starts_with($ts, '0001-01-01')) {
+        return null;
+    }
+    return $ts;
+}
+
+/**
+ * Reshape a gateway StatusResponse into the `netbird status --json` schema the
+ * views were written against, so the CLI remains a drop-in fallback source.
+ *
+ * @param array<string,mixed> $resp
+ * @return array<string,mixed>
+ */
+function mapGatewayStatus(array $resp, string $profileName): array
+{
+    $fs    = is_array($resp['fullStatus']      ?? null) ? $resp['fullStatus']      : [];
+    $local = is_array($fs['localPeerState']    ?? null) ? $fs['localPeerState']    : [];
+    $mgmt  = is_array($fs['managementState']   ?? null) ? $fs['managementState']   : [];
+    $sig   = is_array($fs['signalState']       ?? null) ? $fs['signalState']       : [];
+
+    $peers     = [];
+    $connected = 0;
+    foreach (($fs['peers'] ?? []) as $p) {
+        if (!is_array($p)) {
+            continue;
+        }
+        $state = (string) ($p['connStatus'] ?? '');
+        if ($state === 'Connected') {
+            $connected++;
+        }
+        $peers[] = [
+            'fqdn'             => $p['fqdn'] ?? '',
+            'netbirdIp'        => pbGet($p, ['IP', 'ip'], ''),
+            'netbirdIpv6'      => $p['ipv6'] ?? '',
+            'status'           => $state,
+            'connectionType'   => !empty($p['relayed']) ? 'Relayed' : 'P2P',
+            'iceCandidateType' => [
+                'local'  => $p['localIceCandidateType']  ?? '',
+                'remote' => $p['remoteIceCandidateType'] ?? '',
+            ],
+            'relayAddress'     => $p['relayAddress'] ?? '',
+            'latency'          => pbDurationNs($p['latency'] ?? null),
+            'lastWireguardHandshake' => pbTimestamp($p['lastWireguardHandshake'] ?? null),
+            // int64 arrives as a JSON string per the protobuf JSON mapping.
+            'transferReceived' => (int) ($p['bytesRx'] ?? 0),
+            'transferSent'     => (int) ($p['bytesTx'] ?? 0),
+            'networks'         => $p['networks'] ?? [],
+        ];
+    }
+
+    $relayDetails = [];
+    $relayAvail   = 0;
+    foreach (($fs['relays'] ?? []) as $r) {
+        if (!is_array($r)) {
+            continue;
+        }
+        if (!empty($r['available'])) {
+            $relayAvail++;
+        }
+        $relayDetails[] = [
+            'uri'       => pbGet($r, ['URI', 'uri'], ''),
+            'available' => !empty($r['available']),
+            'error'     => $r['error'] ?? '',
+        ];
+    }
+
+    $dnsServers = [];
+    foreach (($fs['dnsServers'] ?? $fs['dns_servers'] ?? []) as $g) {
+        if (!is_array($g)) {
+            continue;
+        }
+        $dnsServers[] = [
+            'servers' => $g['servers'] ?? [],
+            'domains' => $g['domains'] ?? [],
+            'enabled' => !empty($g['enabled']),
+            'error'   => $g['error'] ?? '',
+        ];
+    }
+
+    return [
+        'daemonStatus'  => $resp['status'] ?? '',
+        'daemonVersion' => $resp['daemonVersion'] ?? '',
+        'profileName'   => $profileName,
+        'netbirdIp'     => pbGet($local, ['IP', 'ip'], ''),
+        'netbirdIpv6'   => $local['ipv6'] ?? '',
+        'publicKey'     => $local['pubKey'] ?? '',
+        'fqdn'          => $local['fqdn'] ?? '',
+        'usesKernelInterface'         => !empty($local['kernelInterface']),
+        'quantumResistance'           => !empty($local['rosenpassEnabled']),
+        'quantumResistancePermissive' => !empty($local['rosenpassPermissive']),
+        'networks'              => $local['networks'] ?? [],
+        'lazyConnectionEnabled' => !empty($fs['lazyConnectionEnabled']),
+        'forwardingRules'       => (int) pbGet($fs, ['NumberOfForwardingRules', 'numberOfForwardingRules'], 0),
+        'management' => [
+            'url'       => pbGet($mgmt, ['URL', 'url'], ''),
+            'connected' => !empty($mgmt['connected']),
+            'error'     => $mgmt['error'] ?? '',
+        ],
+        'signal' => [
+            'url'       => pbGet($sig, ['URL', 'url'], ''),
+            'connected' => !empty($sig['connected']),
+            'error'     => $sig['error'] ?? '',
+        ],
+        'relays' => [
+            'total'     => count($relayDetails),
+            'available' => $relayAvail,
+            'details'   => $relayDetails,
+        ],
+        'dnsServers' => $dnsServers,
+        'peers' => [
+            'total'     => count($peers),
+            'connected' => $connected,
+            'details'   => $peers,
+        ],
+    ];
+}
+
 /**
  * Read JSON status. Returns null if daemon unreachable or output isn't JSON.
+ * Prefers the JSON gateway; falls back to CLI `status --json` (covers daemons
+ * started without --enable-json-socket, e.g. across a plugin upgrade that
+ * hasn't restarted the daemon yet).
  *
  * @return array<string,mixed>|null
  */
 function statusJson(): ?array
 {
+    $res = apiCall('Status', ['getFullPeerStatus' => true], 3);
+    if ($res['ok'] && isset($res['data']['status'])) {
+        $profile = '';
+        $ap = apiCall('GetActiveProfile', [], 3);
+        if ($ap['ok']) {
+            $profile = (string) ($ap['data']['profileName'] ?? '');
+        }
+        return mapGatewayStatus($res['data'], $profile);
+    }
+
     [$rc, $out] = nb(['status', '--json'], 3);
     if ($rc !== 0 || $out === '') {
         return null;
@@ -122,13 +369,36 @@ function readApplyResult(): ?array
 }
 
 /**
- * List NetBird profiles by parsing `netbird profile list` text output.
- * Returns an array of ['name' => string, 'active' => bool].
- * Returns [] when the daemon is unreachable.
+ * List NetBird profiles as ['name' => string, 'active' => bool] entries.
+ * Prefers the JSON gateway's ListProfiles; falls back to parsing the CLI's
+ * text output. Returns [] when the daemon is unreachable.
  *
  * @return array<int, array{name:string, active:bool}>
  */
 function listProfiles(): array
+{
+    $res = apiCall('ListProfiles', ['username' => apiUsername()], 3);
+    if ($res['ok'] && is_array($res['data']['profiles'] ?? null)) {
+        $profiles = [];
+        foreach ($res['data']['profiles'] as $p) {
+            if (is_array($p) && isset($p['name'])) {
+                $profiles[] = [
+                    'name'   => (string) $p['name'],
+                    'active' => !empty(pbGet($p, ['isActive', 'is_active'])),
+                ];
+            }
+        }
+        return $profiles;
+    }
+    return listProfilesCli();
+}
+
+/**
+ * CLI fallback for listProfiles(): parse `netbird profile list` text output.
+ *
+ * @return array<int, array{name:string, active:bool}>
+ */
+function listProfilesCli(): array
 {
     [$rc, $out] = nb(['profile', 'list'], 3);
     if ($rc !== 0) {

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -96,7 +96,17 @@ function apiCall(string $method, array $body = [], int $timeoutSec = 10): array
     curl_close($ch);
 
     if ($raw === false) {
-        return ['ok' => false, 'data' => null, 'error' => "gateway request failed (curl errno $errno)", 'reachable' => false];
+        // A timeout means the daemon accepted the request but didn't answer in
+        // time — it may still be executing the call, so report it reachable to
+        // keep nb_api_or_cli() from re-issuing the operation through the CLI.
+        // Other curl failures (connect refused, etc.) mean the gateway isn't
+        // usable and the CLI fallback is safe.
+        return [
+            'ok'        => false,
+            'data'      => null,
+            'error'     => "gateway request failed (curl errno $errno)",
+            'reachable' => $errno === CURLE_OPERATION_TIMEDOUT,
+        ];
     }
     $decoded = json_decode((string) $raw, true);
     if ($http !== 200) {

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -47,8 +47,10 @@ function nb(array $args, int $timeoutSec = 0): array
 // ---------------------------------------------------------------------------
 // Daemon HTTP/JSON gateway (NetBird >= 0.75, daemon started with
 // --enable-json-socket by rc.netbird). Exposes the daemon gRPC API as
-// POST /daemon.DaemonService/<Method> with protobuf-JSON bodies over a
-// root-only unix socket — structured data without exec()'ing the CLI.
+// POST /daemon.DaemonService/<Method> with protobuf-JSON bodies over a unix
+// socket — structured data without exec()'ing the CLI. NetBird itself chmods
+// the socket 0666 (relying on peer-credential auth for privileged config
+// changes only); rc.netbird tightens it to root-only 0600 after start.
 // ---------------------------------------------------------------------------
 
 const HTTP_SOCK = '/var/run/netbird-http.sock';
@@ -96,16 +98,17 @@ function apiCall(string $method, array $body = [], int $timeoutSec = 10): array
     curl_close($ch);
 
     if ($raw === false) {
-        // A timeout means the daemon accepted the request but didn't answer in
-        // time — it may still be executing the call, so report it reachable to
-        // keep nb_api_or_cli() from re-issuing the operation through the CLI.
-        // Other curl failures (connect refused, etc.) mean the gateway isn't
-        // usable and the CLI fallback is safe.
+        // Only a definite connect-phase failure proves the daemon never saw
+        // the request, making a CLI fallback safe. Anything later — timeout,
+        // send/recv error, empty reply — may have delivered the request, and
+        // the daemon may have executed (or still be executing) it, so report
+        // the gateway reachable to keep nb_api_or_cli() from replaying the
+        // operation through the CLI.
         return [
             'ok'        => false,
             'data'      => null,
             'error'     => "gateway request failed (curl errno $errno)",
-            'reachable' => $errno === CURLE_OPERATION_TIMEDOUT,
+            'reachable' => $errno !== CURLE_COULDNT_CONNECT,
         ];
     }
     $decoded = json_decode((string) $raw, true);
@@ -197,26 +200,31 @@ function mapGatewayStatus(array $resp, string $profileName): array
         if (!is_array($p)) {
             continue;
         }
-        $state = (string) ($p['connStatus'] ?? '');
-        if ($state === 'Connected') {
+        $state  = (string) ($p['connStatus'] ?? '');
+        $isConn = $state === 'Connected';
+        if ($isConn) {
             $connected++;
         }
+        // Mirror the CLI mapper: connection details are only meaningful for a
+        // connected peer — on others the daemon reports stale leftovers, which
+        // the CLI blanks (connectionType "-", empty ICE/relay/handshake/
+        // transfer). Latency and networks are unconditional there too.
         $peers[] = [
             'fqdn'             => $p['fqdn'] ?? '',
             'netbirdIp'        => pbGet($p, ['IP', 'ip'], ''),
             'netbirdIpv6'      => $p['ipv6'] ?? '',
             'status'           => $state,
-            'connectionType'   => !empty($p['relayed']) ? 'Relayed' : 'P2P',
+            'connectionType'   => $isConn ? (!empty($p['relayed']) ? 'Relayed' : 'P2P') : '-',
             'iceCandidateType' => [
-                'local'  => $p['localIceCandidateType']  ?? '',
-                'remote' => $p['remoteIceCandidateType'] ?? '',
+                'local'  => $isConn ? ($p['localIceCandidateType']  ?? '') : '',
+                'remote' => $isConn ? ($p['remoteIceCandidateType'] ?? '') : '',
             ],
-            'relayAddress'     => $p['relayAddress'] ?? '',
+            'relayAddress'     => $isConn ? ($p['relayAddress'] ?? '') : '',
             'latency'          => pbDurationNs($p['latency'] ?? null),
-            'lastWireguardHandshake' => pbTimestamp($p['lastWireguardHandshake'] ?? null),
+            'lastWireguardHandshake' => $isConn ? pbTimestamp($p['lastWireguardHandshake'] ?? null) : null,
             // int64 arrives as a JSON string per the protobuf JSON mapping.
-            'transferReceived' => (int) ($p['bytesRx'] ?? 0),
-            'transferSent'     => (int) ($p['bytesTx'] ?? 0),
+            'transferReceived' => $isConn ? (int) ($p['bytesRx'] ?? 0) : 0,
+            'transferSent'     => $isConn ? (int) ($p['bytesTx'] ?? 0) : 0,
             'networks'         => $p['networks'] ?? [],
         ];
     }

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -408,9 +408,13 @@ function readApplyResult(): ?array
 function listProfiles(): array
 {
     $res = apiCall('ListProfiles', ['username' => apiUsername()], 3);
-    if ($res['ok'] && is_array($res['data']['profiles'] ?? null)) {
+    if ($res['ok']) {
+        // protojson omits empty repeated fields, so a daemon with zero
+        // profiles answers {} — still a successful response, not a reason
+        // to fall back to the CLI.
+        $list = $res['data']['profiles'] ?? [];
         $profiles = [];
-        foreach ($res['data']['profiles'] as $p) {
+        foreach ((is_array($list) ? $list : []) as $p) {
             if (is_array($p) && isset($p['name'])) {
                 $profiles[] = [
                     'name'   => (string) $p['name'],

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -38,6 +38,20 @@ GLOBAL_CFG=/boot/config/plugins/netbird/netbird.cfg
 PROFILE_CFG="/boot/config/plugins/netbird/profiles/${PROFILE}.cfg"
 LOCK_FILE=/var/run/netbird-apply.lock
 RESULT_FILE=/var/run/netbird-apply-result.json
+HTTP_SOCK=/var/run/netbird-http.sock
+
+# Query the daemon's JSON gateway (NetBird >= 0.75, rc.netbird starts it with
+# --enable-json-socket). $1 = method, $2 = JSON body (default {}). Prints the
+# response body; fails when the gateway socket isn't up so callers can fall
+# back to scraping CLI text.
+nb_api() {
+    [ -S "$HTTP_SOCK" ] || return 1
+    _body="${2:-}"
+    [ -n "$_body" ] || _body='{}'
+    curl -sf --max-time 3 --unix-socket "$HTTP_SOCK" \
+         -H 'Content-Type: application/json' -d "$_body" \
+         "http://localhost/daemon.DaemonService/$1" 2>/dev/null
+}
 
 # Record the outcome for the UI poller. $1 = true|false|null, $2 = short message.
 # All values are controlled (profile name is validated upstream; messages are
@@ -116,8 +130,19 @@ done
 # and the daemon is connected, there's nothing to apply — skip the select+up so
 # a no-op save doesn't needlessly bounce the connection.
 if [ "$MODE" = "ensure" ]; then
-    ACTIVE=$("$NB" profile list 2>/dev/null | awk '/^✓/{print $2}')
-    if [ "$ACTIVE" = "$PROFILE" ] && "$NB" status 2>/dev/null | grep -q "Management: Connected"; then
+    # Prefer the JSON gateway for both checks; fall back to scraping CLI text
+    # when the daemon predates it or was started without the socket.
+    ACTIVE=$(nb_api GetActiveProfile | sed -n 's/.*"profileName":"\([^"]*\)".*/\1/p')
+    [ -n "$ACTIVE" ] || ACTIVE=$("$NB" profile list 2>/dev/null | awk '/^✓/{print $2}')
+    STATUS_JSON=$(nb_api Status)
+    if [ -n "$STATUS_JSON" ]; then
+        # protojson omits false booleans, so "connected":true is only ever
+        # present inside managementState when management really is connected.
+        MGMT_UP=$(printf '%s' "$STATUS_JSON" | grep -o '"managementState":{[^}]*}' | grep -c '"connected":true')
+    else
+        MGMT_UP=$("$NB" status 2>/dev/null | grep -c "Management: Connected")
+    fi
+    if [ "$ACTIVE" = "$PROFILE" ] && [ "$MGMT_UP" -ge 1 ]; then
         log "No credential change and '$PROFILE' already active+connected; nothing to apply."
         write_result true "no change (already connected)"
         exit 0

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -134,7 +134,9 @@ if [ "$MODE" = "ensure" ]; then
     # when the daemon predates it or was started without the socket.
     ACTIVE=$(nb_api GetActiveProfile | sed -n 's/.*"profileName":"\([^"]*\)".*/\1/p')
     [ -n "$ACTIVE" ] || ACTIVE=$("$NB" profile list 2>/dev/null | awk '/^✓/{print $2}')
-    STATUS_JSON=$(nb_api Status)
+    # getFullPeerStatus is required: without it the daemon omits fullStatus
+    # (and with it managementState) from the response entirely.
+    STATUS_JSON=$(nb_api Status '{"getFullPeerStatus":true}')
     if [ -n "$STATUS_JSON" ]; then
         # protojson omits false booleans, so "connected":true is only ever
         # present inside managementState when management really is connected.

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -11,6 +11,8 @@ LOGFILE=/var/log/netbird.log
 PIDFILE=/var/run/netbird.pid
 SOCKFILE=/var/run/netbird.sock
 DAEMON_ADDR="unix://${SOCKFILE}"
+HTTPSOCKFILE=/var/run/netbird-http.sock
+JSON_SOCK_ADDR="unix://${HTTPSOCKFILE}"
 DEFAULT_CFG=/usr/local/emhttp/plugins/netbird/default.cfg
 GLOBAL_CFG=/boot/config/plugins/netbird/netbird.cfg
 
@@ -66,12 +68,20 @@ start_netbird() {
         EXTRA_ARGS="$NETBIRD_CUSTOM_PARAMS"
     fi
 
-    # Remove a stale socket left by an unclean exit. NetBird can't bind a socket
+    # Remove stale sockets left by an unclean exit. NetBird can't bind a socket
     # path that already exists on disk and exits immediately, which is why a
     # start right after a crash or hard kill would otherwise silently fail.
-    rm -f "$SOCKFILE"
+    rm -f "$SOCKFILE" "$HTTPSOCKFILE"
 
-    log "Starting netbird: $DAEMON service run --daemon-addr $DAEMON_ADDR --log-file $LOGFILE $EXTRA_ARGS"
+    # JSON gateway (NetBird >= 0.75): expose the daemon gRPC API as JSON over a
+    # root-only unix socket so the web UI can query it without exec'ing the CLI.
+    # Guarded on flag support so an older sideloaded binary still starts.
+    JSON_ARGS=""
+    if "$DAEMON" service run --help 2>/dev/null | grep -q "enable-json-socket"; then
+        JSON_ARGS="--enable-json-socket --json-socket $JSON_SOCK_ADDR"
+    fi
+
+    log "Starting netbird: $DAEMON service run --daemon-addr $DAEMON_ADDR --log-file $LOGFILE $JSON_ARGS $EXTRA_ARGS"
     mkdir -p /var/lib/netbird /etc/netbird
     # 9>&- drops the serialization lock descriptor before handing off to the
     # daemon. Without it the long-lived daemon inherits the lock and holds it
@@ -84,6 +94,7 @@ start_netbird() {
     nohup "$DAEMON" service run \
         --daemon-addr "$DAEMON_ADDR" \
         --log-file "$LOGFILE" \
+        $JSON_ARGS \
         $EXTRA_ARGS >>"$LOGFILE" 2>&1 9>&- &
     echo $! > "$PIDFILE"
 
@@ -123,7 +134,7 @@ stop_netbird() {
 
     if [ -z "$pids" ]; then
         log "NetBird daemon not running."
-        rm -f "$PIDFILE" "$SOCKFILE"
+        rm -f "$PIDFILE" "$SOCKFILE" "$HTTPSOCKFILE"
         return 0
     fi
 
@@ -161,9 +172,9 @@ stop_netbird() {
         log "ERROR: NetBird daemon could not be stopped."
         return 1
     fi
-    # Clear the socket only once the daemon is confirmed gone, so we never strip
-    # the socket out from under a daemon that is still serving.
-    rm -f "$SOCKFILE"
+    # Clear the sockets only once the daemon is confirmed gone, so we never
+    # strip a socket out from under a daemon that is still serving.
+    rm -f "$SOCKFILE" "$HTTPSOCKFILE"
     return 0
 }
 

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -74,7 +74,7 @@ start_netbird() {
     rm -f "$SOCKFILE" "$HTTPSOCKFILE"
 
     # JSON gateway (NetBird >= 0.75): expose the daemon gRPC API as JSON over a
-    # root-only unix socket so the web UI can query it without exec'ing the CLI.
+    # unix socket so the web UI can query it without exec'ing the CLI.
     # Guarded on flag support so an older sideloaded binary still starts.
     JSON_ARGS=""
     if "$DAEMON" service run --help 2>/dev/null | grep -q "enable-json-socket"; then
@@ -109,6 +109,16 @@ start_netbird() {
     done
 
     if [ -S "$SOCKFILE" ] && is_running ; then
+        # Tighten the JSON socket to root-only. NetBird chmods its unix sockets
+        # to 0666 shortly after binding (peer-credential auth only guards
+        # privileged config changes there — ops like Down or RemoveProfile are
+        # open to any local user), and nothing but root's web UI needs this
+        # socket on Unraid. Re-apply after a beat in case our first chmod ran
+        # before the daemon's own.
+        if [ -S "$HTTPSOCKFILE" ]; then
+            chmod 600 "$HTTPSOCKFILE" 2>/dev/null
+            ( sleep 2; chmod 600 "$HTTPSOCKFILE" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
+        fi
         log "NetBird daemon socket is up."
         return 0
     fi

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -117,7 +117,9 @@ start_netbird() {
         # before the daemon's own.
         if [ -S "$HTTPSOCKFILE" ]; then
             chmod 600 "$HTTPSOCKFILE" 2>/dev/null
-            ( sleep 2; chmod 600 "$HTTPSOCKFILE" 2>/dev/null ) >/dev/null 2>&1 </dev/null &
+            # 9>&- so this short-lived watcher doesn't inherit the rc lock
+            # descriptor and extend the lock ~2s past our own exit.
+            ( sleep 2; chmod 600 "$HTTPSOCKFILE" 2>/dev/null ) >/dev/null 2>&1 </dev/null 9>&- &
         fi
         log "NetBird daemon socket is up."
         return 0


### PR DESCRIPTION
## Description

NetBird 0.75.0 added an optional HTTP/JSON gateway for the client daemon
(netbirdio/netbird#6272): with `--enable-json-socket` the daemon exposes its
gRPC API as `POST /daemon.DaemonService/<Method>` with JSON bodies over a
root-only unix socket. The plugin currently gets all of its data by exec'ing
the `netbird` CLI and, in two places, scraping human-readable text (the
`✓ name` lines of `profile list` and grepping `status` for
`Management: Connected`) — both of which silently break whenever upstream
rewords its output.

This PR switches the plugin to the JSON gateway wherever the daemon offers a
first-class method, with the existing CLI paths kept as automatic fallbacks.
No UI changes: gateway responses are mapped onto the same `status --json`
schema the pages already consume.

The gateway is opportunistic everywhere. On upgrades the .plg's synchronous
`rc.netbird restart` brings the socket up immediately for enabled installs;
disabled installs get it on next start. If the socket is missing (older
sideloaded binary, daemon not yet restarted), every consumer degrades to the
current CLI behavior — there is no state where the UI waits on a socket that
isn't there.

## Changes

- **`rc.netbird`** — start the daemon with
  `--enable-json-socket --json-socket unix:///var/run/netbird-http.sock`,
  guarded by a `--help` capability check so an older sideloaded binary still
  starts. The HTTP socket gets the same stale-socket cleanup as the gRPC one.
- **`include/common.php`**
  - New `apiCall()`: POSTs to the gateway over the unix socket via curl (no
    `exec()` per web request). Its result distinguishes "gateway unreachable →
    fall back to CLI" from "daemon answered with an error → surface it".
  - `statusJson()` prefers the gateway (`Status` + `GetActiveProfile`) and
    maps the protobuf JSON onto the exact `netbird status --json` schema the
    views were written against, so `status_view.php` is untouched and the CLI
    stays a drop-in fallback. The mapper handles the protobuf-JSON quirks:
    int64 as strings, durations as `"0.0125s"` (→ ns for `formatLatency()`),
    zero timestamps as the Unix epoch (→ null), omitted false booleans.
  - `listProfiles()` uses `ListProfiles`; the ✓/✗ text parser is demoted to a
    `listProfilesCli()` fallback.
- **`include/action.php`** — `down`, `profile-add`, `profile-remove`, and both
  `profile-select` paths go through the gateway (`Down`, `AddProfile`,
  `RemoveProfile`, `SwitchProfile`) via a `nb_api_or_cli()` helper with CLI
  fallback. `up` deliberately stays on the CLI: the gateway's `UpRequest` only
  takes a profile name, while `netbird up` folds the credential flags into the
  profile and drives registration.
- **`scripts/apply.sh`** — the ensure-mode "already active + connected" check
  asks the gateway (`GetActiveProfile`, `Status`) instead of grepping CLI
  text, falling back to the old scrape when the socket is absent.

## Testing

- `php -l`, PHP-CS-Fixer (dry run), and PHPStan all pass (the CI gates).
- `sh -n` / `bash -n` pass on the shell changes.
- Status mapper smoke-tested against a realistic protojson `StatusResponse`
  payload (30 field checks incl. latency/timestamp/int64 conversions and the
  view's formatting helpers).
- [ ] Verified on Unraid hardware: dashboard renders identically via the
  gateway, profile switching works, socket perms are root-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added faster, more reliable communication with the NetBird service through a local gateway.
  - Profile listing, status checks, connection monitoring, and profile management now use the gateway when available.
  - Added support for improved profile and connection status reporting.

- **Bug Fixes**
  - Gateway errors are reported directly instead of triggering unnecessary fallback attempts.
  - CLI fallback remains available when the gateway cannot be reached.
  - Startup and shutdown now clean up communication sockets more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->