### PR TITLE
chore: update NetBird to 0.76.3

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.76.1">
+<!ENTITY netbirdVer    "0.76.3">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "8a965dc7ffa0426de7f95d713f953472c4036912b7011272f01d118a3e8f6233">
+<!ENTITY netbirdSHA256 "3b7e1e610724169aa0972cf1bd2970b6657a3a6481c4de021f89307e1abf730b">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.76.1",
-  "netbirdSHA256": "8a965dc7ffa0426de7f95d713f953472c4036912b7011272f01d118a3e8f6233"
+  "netbirdVersion": "0.76.3",
+  "netbirdSHA256": "3b7e1e610724169aa0972cf1bd2970b6657a3a6481c4de021f89307e1abf730b"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.76.2` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled NetBird component to version 0.76.3.
  * Updated the associated download verification checksum to match the new release.
  * Download details continue to be generated from the configured NetBird version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->