### PR TITLE
fix: stop the boot-time restart loop that leaves NetBird disconnected

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -234,7 +234,15 @@ fi
 # first nginx reload once wt0 appears.
 if [ "$NETBIRD_EXISTING" = "1" ] || [ "$NETBIRD_HAD_CFG" = "1" ]; then
     if [ "$NETBIRD_ENABLE_AFTER_INSTALL" = "1" ]; then
-        /etc/rc.d/rc.netbird restart
+        # Only restart when a daemon is actually live on the binary we just
+        # replaced. Unraid reinstalls every plugin at boot, and there nothing
+        # is running yet — a restart would just be a no-op stop followed by a
+        # start, colliding with the array_started reconcile moments later.
+        if /usr/bin/pgrep -x netbird >/dev/null 2>&1; then
+            /etc/rc.d/rc.netbird restart
+        else
+            /etc/rc.d/rc.netbird start
+        fi
         (
             for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
                 if ip -4 addr show wt0 >/dev/null 2>&1; then

--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -234,11 +234,22 @@ fi
 # first nginx reload once wt0 appears.
 if [ "$NETBIRD_EXISTING" = "1" ] || [ "$NETBIRD_HAD_CFG" = "1" ]; then
     if [ "$NETBIRD_ENABLE_AFTER_INSTALL" = "1" ]; then
-        # Only restart when a daemon is actually live on the binary we just
-        # replaced. Unraid reinstalls every plugin at boot, and there nothing
-        # is running yet — a restart would just be a no-op stop followed by a
-        # start, colliding with the array_started reconcile moments later.
-        if /usr/bin/pgrep -x netbird >/dev/null 2>&1; then
+        # Only restart when the service daemon is actually live on the binary we
+        # just replaced. Match it the way rc.netbird's running_pids does — by
+        # executable name plus a "service run" command line — so a transient
+        # netbird CLI call (a status poll from the WebGUI during an upgrade, for
+        # instance) is never mistaken for a running daemon. Unraid reinstalls
+        # every plugin at boot, and there nothing is running yet, so a restart
+        # would just be a no-op stop followed by a start, colliding with the
+        # array_started reconcile moments later.
+        NETBIRD_DAEMON_UP=0
+        for _p in $(/usr/bin/pgrep -x netbird 2>/dev/null); do
+            if tr '\0' ' ' < "/proc/$_p/cmdline" 2>/dev/null | grep -q "service run"; then
+                NETBIRD_DAEMON_UP=1
+                break
+            fi
+        done
+        if [ "$NETBIRD_DAEMON_UP" = "1" ]; then
             /etc/rc.d/rc.netbird restart
         else
             /etc/rc.d/rc.netbird start

--- a/src/install/doinst.sh
+++ b/src/install/doinst.sh
@@ -16,11 +16,13 @@ chmod 0644 etc/logrotate.d/netbird
 chown root:root etc/logrotate.d/netbird
 
 # Event hooks: reconcile the daemon when the array starts (rc.netbird keeps a
-# disabled installation stopped).
+# disabled installation stopped). Only array_started is wired up — "started"
+# also fires on a normal boot, so hooking both gave us two redundant triggers
+# on top of the plugin reinstall. The rm clears the stale "started" link left
+# by older installs.
 ( cd usr/local/emhttp/plugins/netbird/event
   rm -f array_started stopped started stopping_svcs
-  ln -sf ../restart.sh array_started
-  ln -sf ../restart.sh started
+  ln -sf ../reconcile.sh array_started
 )
 
 # Make all *.sh executable inside the page tree

--- a/src/install/doinst.sh
+++ b/src/install/doinst.sh
@@ -17,9 +17,10 @@ chown root:root etc/logrotate.d/netbird
 
 # Event hooks: reconcile the daemon when the array starts (rc.netbird keeps a
 # disabled installation stopped). Only array_started is wired up — "started"
-# also fires on a normal boot, so hooking both gave us two redundant triggers
-# on top of the plugin reinstall. The rm clears the stale "started" link left
-# by older installs.
+# fires on every array start too (just later, once services are up), so
+# hooking both ran the same trigger twice per array start, on top of the
+# boot-time plugin reinstall. The rm clears the stale "started" link left by
+# older installs.
 ( cd usr/local/emhttp/plugins/netbird/event
   rm -f array_started stopped started stopping_svcs
   ln -sf ../reconcile.sh array_started

--- a/src/install/slack-desc
+++ b/src/install/slack-desc
@@ -6,7 +6,7 @@ unraid-netbird-utils: pages required to run the NetBird WireGuard-mesh client na
 unraid-netbird-utils: Unraid OS as a system plugin.
 unraid-netbird-utils:
 unraid-netbird-utils: NetBird upstream: https://netbird.io
-unraid-netbird-utils: Plugin source:   https://github.com/techhutus/netbird-unraid
+unraid-netbird-utils: Plugin source:   https://github.com/netbirdio/netbird-unraid
 unraid-netbird-utils:
 unraid-netbird-utils:
 unraid-netbird-utils:

--- a/src/usr/local/emhttp/plugins/netbird/erase.sh
+++ b/src/usr/local/emhttp/plugins/netbird/erase.sh
@@ -14,4 +14,5 @@ rm -rf /boot/config/plugins/netbird/profiles
 rm -f  /boot/config/plugins/netbird/netbird.cfg
 
 log "Restarting NetBird"
-echo "sleep 5 ; /etc/rc.d/rc.netbird restart" | at now 2>/dev/null
+nohup /bin/sh -c 'sleep 5 ; /etc/rc.d/rc.netbird restart' >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true

--- a/src/usr/local/emhttp/plugins/netbird/erase.sh
+++ b/src/usr/local/emhttp/plugins/netbird/erase.sh
@@ -13,6 +13,7 @@ rm -rf /boot/config/plugins/netbird/lib/*
 rm -rf /boot/config/plugins/netbird/profiles
 rm -f  /boot/config/plugins/netbird/netbird.cfg
 
-log "Restarting NetBird"
-nohup /bin/sh -c 'sleep 5 ; /etc/rc.d/rc.netbird restart' >/dev/null 2>&1 </dev/null &
-disown 2>/dev/null || true
+# No restart here: deleting netbird.cfg reverts the install to the packaged
+# default (disabled), so rc.netbird's start would refuse anyway. An erased
+# installation deliberately stays down until it is reconfigured.
+log "NetBird stopped; configuration erased. Enable it again from Settings."

--- a/src/usr/local/emhttp/plugins/netbird/event/README
+++ b/src/usr/local/emhttp/plugins/netbird/event/README
@@ -1,4 +1,6 @@
 This directory is populated at install time by ../install/doinst.sh.
 Expected symlinks:
-  array_started -> ../restart.sh
-  started       -> ../restart.sh
+  array_started -> ../reconcile.sh
+
+Only array_started is hooked. "started" fires on a normal boot too, so wiring
+both gave two redundant triggers on top of the plugin's own boot reinstall.

--- a/src/usr/local/emhttp/plugins/netbird/event/README
+++ b/src/usr/local/emhttp/plugins/netbird/event/README
@@ -2,5 +2,6 @@ This directory is populated at install time by ../install/doinst.sh.
 Expected symlinks:
   array_started -> ../reconcile.sh
 
-Only array_started is hooked. "started" fires on a normal boot too, so wiring
-both gave two redundant triggers on top of the plugin's own boot reinstall.
+Only array_started is hooked. "started" fires on every array start as well
+(just later, once services are up), so wiring both ran the same trigger twice
+per array start, on top of the plugin's own boot-time reinstall.

--- a/src/usr/local/emhttp/plugins/netbird/reconcile.sh
+++ b/src/usr/local/emhttp/plugins/netbird/reconcile.sh
@@ -11,5 +11,8 @@
 # waiting on the socket, and so atd doesn't mail the job's output to root on
 # every boot. rc.netbird still records the cycle in /var/log/netbird-utils.log.
 
+. /usr/local/emhttp/plugins/netbird/include/log.sh 2>/dev/null || log() { echo "$*" ; }
+
+log "array_started: ensuring NetBird is up"
 nohup /bin/sh -c 'sleep 5 ; /etc/rc.d/rc.netbird start' >/dev/null 2>&1 </dev/null &
 disown 2>/dev/null || true

--- a/src/usr/local/emhttp/plugins/netbird/reconcile.sh
+++ b/src/usr/local/emhttp/plugins/netbird/reconcile.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Bring the NetBird daemon up if it isn't already. Wired to the array_started
+# event by ../install/doinst.sh.
+#
+# This deliberately does NOT restart: rc.netbird's start is idempotent and
+# honours ENABLE_NETBIRD, so a healthy daemon is left alone and a deliberately
+# disabled one stays stopped. Tearing down a working daemon on every array
+# start was what produced the boot-time restart storm.
+#
+# Detached with nohup rather than `at` so the event dispatcher isn't blocked
+# waiting on the socket, and so atd doesn't mail the job's output to root on
+# every boot. rc.netbird still records the cycle in /var/log/netbird-utils.log.
+
+nohup /bin/sh -c 'sleep 5 ; /etc/rc.d/rc.netbird start' >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true

--- a/src/usr/local/emhttp/plugins/netbird/restart.sh
+++ b/src/usr/local/emhttp/plugins/netbird/restart.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
-# Restart the NetBird daemon. Used both by the install step and by the
-# "Restart" button on the Status page. Detaches via `at` so the install
-# UI doesn't block waiting for the service.
+# Restart the NetBird daemon. Driven by the "Restart" button on the Status
+# page; the array_started event uses ./reconcile.sh instead, and the installer
+# calls rc.netbird directly.
+#
+# Detaches with nohup rather than `at` so the caller doesn't block on the
+# service and atd doesn't mail the job's output to root on every restart.
 
 . /usr/local/emhttp/plugins/netbird/include/log.sh 2>/dev/null || log() { echo "$*" ; }
 
 log "Restarting NetBird in 5 seconds"
-echo "sleep 5 ; /etc/rc.d/rc.netbird restart" | at now 2>/dev/null
+nohup /bin/sh -c 'sleep 5 ; /etc/rc.d/rc.netbird restart' >/dev/null 2>&1 </dev/null &
+disown 2>/dev/null || true

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -75,7 +75,12 @@ start_netbird() {
     mkdir -p /var/lib/netbird /etc/netbird
     # 9>&- drops the serialization lock descriptor before handing off to the
     # daemon. Without it the long-lived daemon inherits the lock and holds it
-    # until it exits, wedging every subsequent start/stop/restart.
+    # until it exits, wedging every subsequent start/stop/restart. The same
+    # close also protects the caller's FD 9: apply.sh invokes us while holding
+    # its apply lock there, and a daemon that inherited that descriptor kept
+    # /var/run/netbird-apply.lock held for its whole lifetime — every later
+    # save/connect then failed with "another operation was in progress" until
+    # something restarted the daemon.
     nohup "$DAEMON" service run \
         --daemon-addr "$DAEMON_ADDR" \
         --log-file "$LOGFILE" \

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -73,10 +73,13 @@ start_netbird() {
 
     log "Starting netbird: $DAEMON service run --daemon-addr $DAEMON_ADDR --log-file $LOGFILE $EXTRA_ARGS"
     mkdir -p /var/lib/netbird /etc/netbird
+    # 9>&- drops the serialization lock descriptor before handing off to the
+    # daemon. Without it the long-lived daemon inherits the lock and holds it
+    # until it exits, wedging every subsequent start/stop/restart.
     nohup "$DAEMON" service run \
         --daemon-addr "$DAEMON_ADDR" \
         --log-file "$LOGFILE" \
-        $EXTRA_ARGS >>"$LOGFILE" 2>&1 &
+        $EXTRA_ARGS >>"$LOGFILE" 2>&1 9>&- &
     echo $! > "$PIDFILE"
 
     # Wait for the socket, but bail early if the process dies (e.g. a bind
@@ -176,6 +179,33 @@ status_netbird() {
         return 1
     fi
 }
+
+# Serialize the mutating verbs. Boot fires several triggers within seconds of
+# each other (Unraid reinstalls every plugin at startup, then the array_started
+# event lands), and without a lock one invocation's stop — which allows ~6s for
+# a graceful exit and up to ~10s more to escalate — lands on the daemon another
+# invocation just started. Two daemons then race for the socket, and that
+# interleave is what reads as a restart loop. "status" deliberately stays
+# outside the lock so the WebGUI never blocks behind an in-flight restart.
+#
+# The lock is held on an explicit descriptor we control rather than via the
+# "flock <file> <command>" wrapper form. That form leaves its descriptor open
+# across the exec without FD_CLOEXEC, so the daemon started underneath it
+# inherits the lock and holds it for its entire lifetime — every later
+# start/stop then blocks until the timeout expires and gives up. start_netbird
+# closes this descriptor for the daemon it launches, for the same reason.
+LOCKFILE=/var/run/netbird-rc.lock
+case "$1" in
+    start|stop|restart)
+        if [ -x /usr/bin/flock ]; then
+            exec 9>"$LOCKFILE"
+            if ! /usr/bin/flock -w 120 9 ; then
+                log "ERROR: timed out waiting for another netbird $1 to finish."
+                exit 1
+            fi
+        fi
+        ;;
+esac
 
 case "$1" in
     start)   start_netbird   ;;


### PR DESCRIPTION
# Description

Fixes #39 that reported NetBird going into a restart loop after every reboot, plus an email and a blue banner in the WebGUI each time. Confirmed on Unraid 7.3.2.

Three things restarted the daemon on every boot:

1. `netbird.plg` ran `rc.netbird restart`. Unraid reinstalls plugins at boot, so this ran each time.
2. `event/array_started` ran `restart.sh`, which scheduled `at now: sleep 5 ; rc.netbird restart`.
3. `event/started` ran the same thing. `doinst.sh` linked both events, and both fire on a boot.

Nothing serialized them. A stop allows ~6s for a graceful exit plus ~10s to escalate to SIGKILL, and the two `at` jobs were only 5s apart, so one job's stop hit the daemon another had just started:

```
10:37:35 Stopping netbird daemon.
10:37:35 Stopping netbird daemon.
10:37:38 Starting netbird: ...
10:37:38 Starting netbird: ...
```

Two daemons come up at once. Both run `start_netbird`, which begins with `rm -f "$SOCKFILE"`, so one can delete the socket the other just bound. That leaves a daemon running that nothing can talk to, which the UI reports as down. That's the "constant restart" in the issue.

The email is `atd` mailing each job's stdout to root, and the banner is `log()` echoing to stdout.

The event hooks never needed to restart anything. `rc.netbird start` is already idempotent and already respects `ENABLE_NETBIRD`, which is what the hook wanted all along.

# Changes

`rc.netbird`: serialize start/stop/restart with flock on `/var/run/netbird-rc.lock`. `status` stays unlocked so the WebGUI doesn't block behind a restart.

The lock is held on fd 9 instead of using `flock <file> <command>`, and `start_netbird` closes it with `9>&-`. That form of flock doesn't set FD_CLOEXEC, so the daemon inherits the lock and holds it until it exits, which blocks every later start/stop until the timeout expires. I hit this on the test box before it went anywhere near a release, so it's worth not undoing.

`reconcile.sh` (new): the `array_started` hook now calls `rc.netbird start` instead of restarting. Leaves a healthy daemon alone, leaves a disabled one stopped. Uses `nohup` instead of `at` so it doesn't block the event dispatcher or mail root.

`doinst.sh`: link only `array_started`. The existing `rm -f` clears the stale `started` link on upgrade.

`netbird.plg`: only restart if a daemon is actually running. At boot nothing is up yet so it starts; on a real upgrade the daemon is on the old binary and still gets restarted.

`restart.sh`, `erase.sh`: replace `at now` with `nohup`. Stops the root mail from #39. Both keep the 5s delay and still log to `/var/log/netbird-utils.log`.

`event/README`: note that only `array_started` is hooked.

# Testing

Tested on live hardware, Unraid 7.3.2 with NetBird 0.76.3.

After a real reboot:

```
boot: 12:25:32
12:28:21  Starting netbird: ...
12:28:22  NetBird daemon socket is up.
12:29:23  NetBird daemon already running.
```

One start, no stops. The array came up 62s after the plugin install, which is where the old code fired restarts two and three.

75 checks, no failures. Installed files match the package byte for byte, `sh -n` and `php -l` are clean. Verb semantics cover rc codes, idempotent start, socket and pidfile cleanup. Six concurrent restarts alternate strictly stop/start with no two stops in a row, one daemon left, no lock holders. Recovers from a stale socket file, and a stale pidfile pointing at an unrelated process doesn't kill it. With `ENABLE_NETBIRD="0"` both `rc.netbird start` and the hook refuse to start. The UI restart button returns in about 3ms with no `at` jobs queued.

Not covered: `erase.sh` wasn't run against a live install since it wipes identity, though its `at` removal matches `restart.sh`. Only tested on 7.3.2 / x86_64. `flock` is present on 7.3.2; if it were missing the guard falls back to current behavior rather than breaking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NetBird startup, restart, and boot-time recovery handling.
  * Avoided unnecessary restarts for healthy or disabled services.
  * Prevented background processes from retaining locks and improved command serialization.
  * Made delayed restarts more reliable without relying on active terminal sessions.
  * NetBird remains stopped after configuration removal until re-enabled in Settings.

* **Documentation**
  * Updated startup event documentation to reflect the streamlined behavior.
  * Updated the plugin source reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->