### PR TITLE
chore: update NetBird to 0.77.0

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.76.3">
+<!ENTITY netbirdVer    "0.77.0">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "3b7e1e610724169aa0972cf1bd2970b6657a3a6481c4de021f89307e1abf730b">
+<!ENTITY netbirdSHA256 "9a2c6eb7a086061ce51e06b86f546f6385c14eee9b30c87ee29d47c77558aade">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.76.3",
-  "netbirdSHA256": "3b7e1e610724169aa0972cf1bd2970b6657a3a6481c4de021f89307e1abf730b"
+  "netbirdVersion": "0.77.0",
+  "netbirdSHA256": "9a2c6eb7a086061ce51e06b86f546f6385c14eee9b30c87ee29d47c77558aade"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.77.0` (version + SHA256 verified against netbirdio/netbird).