### PR TITLE
chore: update NetBird to 0.77.1

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.77.0">
+<!ENTITY netbirdVer    "0.77.1">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "9a2c6eb7a086061ce51e06b86f546f6385c14eee9b30c87ee29d47c77558aade">
+<!ENTITY netbirdSHA256 "c4e819ccd0337a73f6d9f42723728201c114bc64b9d735d55ae967ad7f4265d4">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.77.0",
-  "netbirdSHA256": "9a2c6eb7a086061ce51e06b86f546f6385c14eee9b30c87ee29d47c77558aade"
+  "netbirdVersion": "0.77.1",
+  "netbirdSHA256": "c4e819ccd0337a73f6d9f42723728201c114bc64b9d735d55ae967ad7f4265d4"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.77.1` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled NetBird version to 0.77.1.
  * Refreshed download details and verification data for the updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->