### PR TITLE
fix: prevent strict Rosenpass from locking out the host

### DIFF
--- a/src/usr/local/emhttp/plugins/netbird/Netbird-1-Settings.page
+++ b/src/usr/local/emhttp/plugins/netbird/Netbird-1-Settings.page
@@ -204,12 +204,12 @@ Runs NetBird's built-in SSH server so other peers can SSH into this Unraid host 
 _(Enable Rosenpass)_:
 : <select name="ENABLE_ROSENPASS">
   <?=mk_option($rosenpass, "0", _("No"))?>
-  <?=mk_option($rosenpass, "1", _("Yes"))?>
-  <?=mk_option($rosenpass, "permissive", _("Yes (permissive)"))?>
+  <?=mk_option($rosenpass, "permissive", _("Yes (permissive, recommended)"))?>
+  <?=mk_option($rosenpass, "1", _("Yes (strict)"))?>
   </select>
 
 <blockquote class="inline_help">
-Enables <a href="https://docs.netbird.io/how-to/enable-post-quantum-cryptography" target="_blank" rel="noopener noreferrer">Rosenpass post-quantum cryptography</a>: NetBird negotiates WireGuard pre-shared keys with a quantum-resistant handshake. <b>Yes</b> only connects to peers that also run Rosenpass. <b>Yes (permissive)</b> uses Rosenpass where the other peer supports it and falls back to a standard WireGuard connection otherwise — use this in a mixed network. Changing this reconnects NetBird to take effect.
+Enables <a href="https://docs.netbird.io/client/post-quantum-cryptography" target="_blank" rel="noopener noreferrer">Rosenpass post-quantum cryptography</a>, which NetBird marks <b>experimental</b>: WireGuard pre-shared keys are negotiated with a quantum-resistant handshake. It is agreed per pair of peers, so <b>both ends need it enabled</b> before a link is actually protected — there is no network-wide switch in the dashboard. <b>Yes (permissive)</b> uses Rosenpass with peers that have it and plain WireGuard with those that don't; it is the right choice for a mixed network and can never cut a peer off. <b>Yes (strict)</b> refuses every peer that does not run Rosenpass: those peers lose this host while NetBird still reports them as "Connected", and the setting survives a reboot, so recovering a headless server needs another peer with Rosenpass or local access to the machine. Changing this reconnects NetBird to take effect.
 </blockquote>
 
 : <input type="button" value="_(Apply)_" onclick="nbSaveSettings()"><input type="button" value="_(Done)_" onclick="done()">
@@ -252,6 +252,10 @@ function nbProfileAdd() {
 function nbViewProfile(name) {
     if (name) { nbReloadTo(name); }
 }
+// Rosenpass mode currently persisted in netbird.cfg, so the strict-mode confirm
+// fires on the transition into it rather than on every Apply.
+var nbRosenpassWas = <?=json_encode((string) $rosenpass)?>;
+
 // Save the global options + the edited profile's credentials, then apply.
 function nbSaveSettings() {
     var profile = $('#nb-edit-profile').val();
@@ -282,6 +286,32 @@ function nbSaveSettings() {
         PRESHARED_KEY:  $('input[name=PRESHARED_KEY]', form).val(),
         csrf_token:     nbCsrfToken
     };
+    // Strict Rosenpass severs every peer that doesn't also run it -- including the
+    // browser applying this change, if it reaches Unraid over NetBird. Confirm
+    // before arming it, but only when it isn't already on, so routine applies of
+    // unrelated settings aren't nagged.
+    if (data.ENABLE_ROSENPASS === '1' && nbRosenpassWas !== '1') {
+        swal({
+            title: 'Require Rosenpass from every peer?',
+            text: 'Peers that do not also run Rosenpass will lose their connection to this host, '
+                + 'while NetBird still reports them as "Connected". The setting survives a reboot, '
+                + 'so recovering needs another peer with Rosenpass enabled, or local access to this '
+                + 'machine. Choose "Yes (permissive)" for post-quantum protection without cutting '
+                + 'anyone off.',
+            type: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Enable strict',
+            cancelButtonText: 'Cancel'
+        }, function(confirmed){
+            if (confirmed) { nbPostSettings(profile, data); }
+        });
+        return;
+    }
+    nbPostSettings(profile, data);
+}
+
+// POST the settings payload, then report the result or poll apply.sh for it.
+function nbPostSettings(profile, data) {
     $.post('/plugins/netbird/include/action.php', data, function(resp){
         if (resp && resp.pending) {
             // apply.sh runs in the background; poll for its result so we can

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -150,6 +150,19 @@ function nb_up_args(array $creds): array
     return $args;
 }
 
+/**
+ * Fire the strict-Rosenpass watchdog in the background. `up` from this file
+ * bypasses apply.sh, so without this a Connect or a profile switch could arm a
+ * lockout with nothing verifying it. No-op unless the global setting is strict.
+ */
+function nb_rosenpass_watchdog(): void
+{
+    if ((string) (Netbird\readCfg()['ENABLE_ROSENPASS'] ?? '0') !== '1') {
+        return;
+    }
+    exec('/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh 0 30 > /dev/null 2>&1 &');
+}
+
 switch ($action) {
     case 'up':
         $lock = nb_lock_or_busy();
@@ -206,6 +219,9 @@ switch ($action) {
         // this call without reimplementing SetConfig+Login here.
         [$rc, $out] = Netbird\nb(nb_up_args($creds), 90);
         Netbird\nbUnlock($lock);
+        if ($rc === 0) {
+            nb_rosenpass_watchdog();
+        }
         echo json_encode([
             'type'    => $rc === 0 ? 'success' : 'error',
             'title'   => $rc === 0 ? 'Connecting' : 'NetBird up failed',
@@ -348,6 +364,9 @@ switch ($action) {
         // reconnect can't hang the request.
         [$rcUp, $outUp] = Netbird\nb(nb_up_args(Netbird\readProfileCfg($name)), 90);
         Netbird\nbUnlock($lock);
+        if ($rcUp === 0) {
+            nb_rosenpass_watchdog();
+        }
         echo json_encode([
             'type'    => 'success',
             'title'   => 'Profile switched',

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -145,22 +145,36 @@ function nb_up_args(array $creds): array
     // off. Pass explicit booleans either way so toggling off actually disables
     // it — NetBird remembers the last flag value on the profile otherwise.
     $rosenpass = (string) (Netbird\readCfg()['ENABLE_ROSENPASS'] ?? '0');
+    // Strict is the one mode that can strand this host, and the watchdog is what
+    // undoes that. If it isn't there to run, connect permissively instead: same
+    // post-quantum protection where the other peer supports it, no lockout.
+    if ($rosenpass === '1' && !nb_rosenpass_guard_available()) {
+        $rosenpass = 'permissive';
+    }
     $args[] = '--enable-rosenpass='     . (in_array($rosenpass, ['1', 'permissive'], true) ? 'true' : 'false');
     $args[] = '--rosenpass-permissive=' . ($rosenpass === 'permissive' ? 'true' : 'false');
     return $args;
 }
+
+const NB_ROSENPASS_WATCHDOG = '/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh';
 
 /**
  * Fire the strict-Rosenpass watchdog in the background. `up` from this file
  * bypasses apply.sh, so without this a Connect or a profile switch could arm a
  * lockout with nothing verifying it. No-op unless the global setting is strict.
  */
+function nb_rosenpass_guard_available(): bool
+{
+    return is_executable(NB_ROSENPASS_WATCHDOG)
+        && is_readable('/usr/local/emhttp/plugins/netbird/include/rosenpass.sh');
+}
+
 function nb_rosenpass_watchdog(): void
 {
     if ((string) (Netbird\readCfg()['ENABLE_ROSENPASS'] ?? '0') !== '1') {
         return;
     }
-    exec('/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh 0 30 > /dev/null 2>&1 &');
+    exec(NB_ROSENPASS_WATCHDOG . ' 0 30 > /dev/null 2>&1 &');
 }
 
 switch ($action) {

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -159,9 +159,9 @@ function nb_up_args(array $creds): array
 const NB_ROSENPASS_WATCHDOG = '/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh';
 
 /**
- * Fire the strict-Rosenpass watchdog in the background. `up` from this file
- * bypasses apply.sh, so without this a Connect or a profile switch could arm a
- * lockout with nothing verifying it. No-op unless the global setting is strict.
+ * Whether the strict-Rosenpass safety net is installed and usable. Both halves
+ * are needed: the watchdog script to run the check, and the shared guard it
+ * sources to perform it.
  */
 function nb_rosenpass_guard_available(): bool
 {
@@ -169,6 +169,11 @@ function nb_rosenpass_guard_available(): bool
         && is_readable('/usr/local/emhttp/plugins/netbird/include/rosenpass.sh');
 }
 
+/**
+ * Fire the strict-Rosenpass watchdog in the background. `up` from this file
+ * bypasses apply.sh, so without this a Connect or a profile switch could arm a
+ * lockout with nothing verifying it. No-op unless the global setting is strict.
+ */
 function nb_rosenpass_watchdog(): void
 {
     if ((string) (Netbird\readCfg()['ENABLE_ROSENPASS'] ?? '0') !== '1') {

--- a/src/usr/local/emhttp/plugins/netbird/include/rosenpass.sh
+++ b/src/usr/local/emhttp/plugins/netbird/include/rosenpass.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+# Shared strict-Rosenpass safety net.
+#
+# Sourced by apply.sh and by scripts/rosenpass-watchdog.sh, so every path that
+# can bring a profile up while strict is armed gets the same verification
+# instead of only the Settings save path. Callers need $NB, $GLOBAL_CFG,
+# $ENABLE_ROSENPASS and a log() function.
+
+# Peer handshake census, used to tell a live data plane from a dead one. Prints
+# "<peers> <with-a-completed-handshake>". NetBird zeroes the handshake timestamp
+# (0001-01-01) until a peer actually completes one, while still reporting the
+# peer as "Connected", so this is the only honest liveness signal available.
+nb_handshake_stats() {
+    _hs_out=$("$NB" status --json 2>/dev/null) || return 1
+    [ -n "$_hs_out" ] || return 1
+    # Shape check only: a truncated or plain-text reply must not reach the
+    # counter, where it would read as "no peers".
+    case "$_hs_out" in '{'*'}') ;; *) return 1 ;; esac
+    case "$_hs_out" in *'"peers"'*) ;; *) return 1 ;; esac
+    printf '%s\n' "$_hs_out" \
+        | grep -o '"lastWireguardHandshake":"[^"]*"' \
+        | awk '{t++} $0 !~ /0001-01-01/ {l++} END{printf "%d %d\n", t+0, l+0}'
+}
+
+# Write permissive, then read it back: a failed sed or read-only /boot must not
+# be reported as a durable revert.
+nb_persist_rosenpass_permissive() {
+    if grep -q '^ENABLE_ROSENPASS=' "$GLOBAL_CFG" 2>/dev/null; then
+        sed -i 's/^ENABLE_ROSENPASS=.*/ENABLE_ROSENPASS="permissive"/' "$GLOBAL_CFG" || return 1
+    else
+        # Without a trailing newline the key would glue onto the last line.
+        if [ -s "$GLOBAL_CFG" ] && [ -n "$(tail -c 1 "$GLOBAL_CFG")" ]; then
+            printf '\n' >> "$GLOBAL_CFG" || return 1
+        fi
+        printf 'ENABLE_ROSENPASS="permissive"\n' >> "$GLOBAL_CFG" || return 1
+    fi
+    grep -q '^ENABLE_ROSENPASS="permissive"$' "$GLOBAL_CFG" 2>/dev/null
+}
+
+nb_live_rosenpass_permissive() {
+    "$NB" status 2>/dev/null | grep -qi 'quantum resistance.*permissive'
+}
+
+# Commit-confirm for strict Rosenpass, like a router's "reload in 5": strict
+# refuses peers that don't run it and the setting survives a reboot, so prove the
+# data plane works before leaving it armed. 0 = keep strict (a handshake landed,
+# or no peers for the whole window), 1 = peers but no handshake, 2 = status
+# unreadable. Non-zero reverts; "unknown" must not read as "fine". Zero peers is
+# only believed if it holds all window, since the list is empty just after `up`.
+rosenpass_commit_confirm() {
+    _rp_deadline=$(( $(date +%s) + ${RP_CONFIRM_WINDOW:-30} ))
+    _rp_saw_status=0
+    _rp_saw_peers=0
+    while :; do
+        if _rp_census=$(nb_handshake_stats); then
+            _rp_saw_status=1
+            set -- $_rp_census
+            [ "${1:-0}" -gt 0 ] && _rp_saw_peers=1
+            [ "${2:-0}" -gt 0 ] && return 0
+        fi
+        [ "$(date +%s)" -ge "$_rp_deadline" ] && break
+        sleep 5
+    done
+    [ "$_rp_saw_status" -eq 0 ] && return 2
+    [ "$_rp_saw_peers" -eq 1 ] && return 1
+    return 0
+}
+
+# The whole safety net in one call. $1 = the `up` argument string to reconnect
+# with (defaults to just the Rosenpass flags, which is all a revert needs since
+# NetBird keeps the profile's other values). Sets RP_GUARD_MSG for the caller's
+# result reporting. Returns 0 nothing-to-do-or-verified, 1 reverted, 2 revert
+# needed but incomplete.
+rosenpass_guard() {
+    RP_GUARD_MSG="connected"
+    [ "${ENABLE_ROSENPASS:-0}" = "1" ] || return 0
+
+    rosenpass_commit_confirm
+    _rp_rc=$?
+    [ "$_rp_rc" -eq 0 ] && return 0
+    if [ "$_rp_rc" -eq 1 ]; then
+        _rp_why="no peer completed a handshake"
+    else
+        _rp_why="peer status was unreadable"
+    fi
+    log "Strict Rosenpass: $_rp_why within ${RP_CONFIRM_WINDOW:-30}s; reverting to permissive."
+
+    # Persist the safer value first so a reboot can't re-arm the lockout.
+    if ! nb_persist_rosenpass_permissive; then
+        log "ERROR: could not write ENABLE_ROSENPASS=permissive to $GLOBAL_CFG; strict stays armed for the next boot."
+        RP_GUARD_MSG="strict Rosenpass unverified ($_rp_why) and the permissive fallback could not be saved"
+        return 2
+    fi
+
+    _rp_args="${1:-up --enable-rosenpass=true --rosenpass-permissive=true}"
+    _rp_args=$(printf '%s' "$_rp_args" | sed 's/--rosenpass-permissive=false/--rosenpass-permissive=true/')
+    # `down` first: `up` on a live profile is a no-op (see 'reconnect').
+    if ! "$NB" down >/dev/null 2>&1; then
+        log "WARN: netbird down failed before the permissive retry; the following up may be a no-op."
+    fi
+    _rp_out=$(timeout 90 "$NB" $_rp_args 2>&1)
+    _rp_up=$?
+    if [ "$_rp_up" -ne 0 ]; then
+        log "Permissive Rosenpass reconnect failed (rc=$_rp_up): $_rp_out"
+        RP_GUARD_MSG="strict Rosenpass unverified ($_rp_why); permissive retry failed (rc=$_rp_up)"
+        return 2
+    fi
+    if ! nb_live_rosenpass_permissive; then
+        log "Permissive reconnect returned success but the daemon is not in permissive mode."
+        RP_GUARD_MSG="strict Rosenpass unverified ($_rp_why); permissive is not in effect"
+        return 2
+    fi
+    log "Reconnected with permissive Rosenpass."
+    RP_GUARD_MSG="strict Rosenpass unverified ($_rp_why); reverted to permissive"
+    return 1
+}

--- a/src/usr/local/emhttp/plugins/netbird/include/status_view.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/status_view.php
@@ -13,6 +13,28 @@ $status    = $daemonReady ? Netbird\statusJson() : null;
 // Whether the plugin lets NetBird manage host DNS (MANAGE_DNS, default on).
 $manageDns = ($cfg['MANAGE_DNS'] ?? '1') === '1';
 
+// Rosenpass health. The exchange is negotiated pairwise, so a peer running it in
+// strict mode refuses the WireGuard handshake with peers that don't -- while
+// NetBird still reports those peers as "Connected". That leaves a live-looking
+// tunnel carrying nothing, which is invisible unless we say so, and it can
+// strand a headless host (the setting persists on flash across reboots). Flag
+// the signature: Rosenpass strict, peers connected, not one handshake completed.
+$rpEnabled    = !empty($status['quantumResistance']);
+$rpPermissive = !empty($status['quantumResistancePermissive']);
+$rpConnected  = 0;
+$rpHandshaken = 0;
+foreach (($status['peers']['details'] ?? []) as $rpPeer) {
+    if (($rpPeer['status'] ?? '') !== 'Connected') {
+        continue;
+    }
+    $rpConnected++;
+    $rpHs = (string) ($rpPeer['lastWireguardHandshake'] ?? '');
+    if ($rpHs !== '' && !str_starts_with($rpHs, '0001-01-01')) {
+        $rpHandshaken++;
+    }
+}
+$rpStalled = $rpEnabled && !$rpPermissive && $rpConnected > 0 && $rpHandshaken === 0;
+
 // The host's live resolver, so issue #2 ("NetBird took over my DNS") is visible
 // at a glance: when management is on, NetBird rewrites this to point at its own
 // embedded resolver. Parse the nameserver lines out of /etc/resolv.conf.
@@ -137,9 +159,22 @@ if ($daemonReady && !$status) {
             </div>
             <div>WireGuard interface</div>
             <div><?=!empty($status['usesKernelInterface']) ? 'Kernel module' : 'Userspace (wireguard-go)'?></div>
-            <?php if (!empty($status['quantumResistance'])): ?>
+            <?php if ($rpEnabled): ?>
                 <div>Rosenpass</div>
-                <div>Enabled<?=!empty($status['quantumResistancePermissive']) ? ' (permissive)' : ''?></div>
+                <div>
+                    <span class="<?=$rpStalled ? 'nb-bad' : 'nb-ok'?>">
+                        Enabled<?=$rpPermissive ? ' (permissive)' : ' (strict)'?>
+                    </span>
+                    <?php if ($rpStalled): ?>
+                        <div class="nb-bad" style="font-size:0.9em;">
+                            <?=$rpConnected?> peer<?=$rpConnected === 1 ? '' : 's'?> report as connected but
+                            none has completed a WireGuard handshake, so this host is carrying no peer
+                            traffic. Strict Rosenpass refuses peers that don't run it, and NetBird still
+                            shows them as "Connected". Set Rosenpass to <b>Yes (permissive)</b> or
+                            <b>No</b> on the Settings tab, or enable Rosenpass on the other peers.
+                        </div>
+                    <?php endif; ?>
+                </div>
             <?php endif; ?>
             <?php if (isset($status['lazyConnectionEnabled']) && $status['lazyConnectionEnabled']): ?>
                 <div>Lazy connections</div><div>Enabled</div>

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -24,6 +24,14 @@
 # each other. Result of the run is written to RESULT_FILE for the UI to poll.
 
 . /usr/local/emhttp/plugins/netbird/include/log.sh 2>/dev/null || log() { echo "$*" ; }
+# Strict-Rosenpass safety net, shared with the watchdog the Connect / profile
+# switch / boot paths fire. Without it we still connect, but unverified.
+if [ -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ]; then
+    . /usr/local/emhttp/plugins/netbird/include/rosenpass.sh
+else
+    log "WARN: include/rosenpass.sh missing; strict Rosenpass will not be verified."
+    rosenpass_guard() { RP_GUARD_MSG="connected"; return 0; }
+fi
 
 PROFILE="$1"
 MODE="${2:-ensure}"
@@ -257,65 +265,6 @@ else
     fi
 fi
 
-# Peer handshake census, used to tell a live data plane from a dead one. Prints
-# "<peers> <with-a-completed-handshake>". NetBird zeroes the handshake timestamp
-# (0001-01-01) until a peer actually completes one, while still reporting the
-# peer as "Connected", so this is the only honest liveness signal available.
-nb_handshake_stats() {
-    _hs_out=$("$NB" status --json 2>/dev/null) || return 1
-    [ -n "$_hs_out" ] || return 1
-    # Shape check only: a truncated or plain-text reply must not reach the
-    # counter, where it would read as "no peers".
-    case "$_hs_out" in '{'*'}') ;; *) return 1 ;; esac
-    case "$_hs_out" in *'"peers"'*) ;; *) return 1 ;; esac
-    printf '%s\n' "$_hs_out" \
-        | grep -o '"lastWireguardHandshake":"[^"]*"' \
-        | awk '{t++} $0 !~ /0001-01-01/ {l++} END{printf "%d %d\n", t+0, l+0}'
-}
-
-# Write permissive, then read it back: a failed sed or read-only /boot must not
-# be reported as a durable revert.
-nb_persist_rosenpass_permissive() {
-    if grep -q '^ENABLE_ROSENPASS=' "$GLOBAL_CFG" 2>/dev/null; then
-        sed -i 's/^ENABLE_ROSENPASS=.*/ENABLE_ROSENPASS="permissive"/' "$GLOBAL_CFG" || return 1
-    else
-        # Without a trailing newline the key would glue onto the last line.
-        if [ -s "$GLOBAL_CFG" ] && [ -n "$(tail -c 1 "$GLOBAL_CFG")" ]; then
-            printf '\n' >> "$GLOBAL_CFG" || return 1
-        fi
-        printf 'ENABLE_ROSENPASS="permissive"\n' >> "$GLOBAL_CFG" || return 1
-    fi
-    grep -q '^ENABLE_ROSENPASS="permissive"$' "$GLOBAL_CFG" 2>/dev/null
-}
-
-nb_live_rosenpass_permissive() {
-    "$NB" status 2>/dev/null | grep -qi 'quantum resistance.*permissive'
-}
-
-# Commit-confirm for strict Rosenpass, like a router's "reload in 5": strict
-# refuses peers that don't run it and the setting survives a reboot, so prove the
-# data plane works before leaving it armed. 0 = keep strict (a handshake landed,
-# or no peers for the whole window), 1 = peers but no handshake, 2 = status
-# unreadable. Non-zero reverts; "unknown" must not read as "fine". Zero peers is
-# only believed if it holds all window, since the list is empty just after `up`.
-rosenpass_commit_confirm() {
-    _rp_deadline=$(( $(date +%s) + 30 ))
-    _rp_saw_status=0
-    _rp_saw_peers=0
-    while :; do
-        if _rp_census=$(nb_handshake_stats); then
-            _rp_saw_status=1
-            set -- $_rp_census
-            [ "${1:-0}" -gt 0 ] && _rp_saw_peers=1
-            [ "${2:-0}" -gt 0 ] && return 0
-        fi
-        [ "$(date +%s)" -ge "$_rp_deadline" ] && break
-        sleep 5
-    done
-    [ "$_rp_saw_status" -eq 0 ] && return 2
-    [ "$_rp_saw_peers" -eq 1 ] && return 1
-    return 0
-}
 
 log "Running: netbird up (profile '$PROFILE', mode '$MODE')"
 OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
@@ -324,45 +273,12 @@ echo "$OUT" >> /var/log/netbird-utils.log
 if [ "$RC" -eq 0 ]; then
     log "netbird up succeeded for profile '$PROFILE'."
     reload_nginx_when_wt0_ready
-    RP_CONFIRM=0
-    if [ "$ENABLE_ROSENPASS" = "1" ]; then
-        rosenpass_commit_confirm
-        RP_CONFIRM=$?
-    fi
-    if [ "$RP_CONFIRM" -eq 0 ]; then
-        write_result true "connected"
-    else
-        if [ "$RP_CONFIRM" -eq 1 ]; then
-            RP_WHY="no peer completed a handshake"
-        else
-            RP_WHY="peer status was unreadable"
-        fi
-        log "Strict Rosenpass: $RP_WHY within 30s; reverting to permissive."
-        # Persist the safer value first so a reboot can't re-arm the lockout.
-        if ! nb_persist_rosenpass_permissive; then
-            log "ERROR: could not write ENABLE_ROSENPASS=permissive to $GLOBAL_CFG; strict stays armed for the next boot."
-            write_result false "strict Rosenpass unverified ($RP_WHY) and the permissive fallback could not be saved"
-        else
-            UP_ARGS=$(printf '%s' "$UP_ARGS" | sed 's/--rosenpass-permissive=false/--rosenpass-permissive=true/')
-            # `down` first: `up` on a live profile is a no-op (see 'reconnect').
-            if ! "$NB" down >/dev/null 2>&1; then
-                log "WARN: netbird down failed before the permissive retry; the following up may be a no-op."
-            fi
-            OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
-            RC=$?
-            echo "$OUT" >> /var/log/netbird-utils.log
-            if [ "$RC" -ne 0 ]; then
-                log "Permissive Rosenpass reconnect failed (rc=$RC): $OUT"
-                write_result false "strict Rosenpass unverified ($RP_WHY); permissive retry failed (rc=$RC)"
-            elif ! nb_live_rosenpass_permissive; then
-                log "Permissive reconnect returned success but the daemon is not in permissive mode."
-                write_result false "strict Rosenpass unverified ($RP_WHY); permissive is not in effect"
-            else
-                log "Reconnected with permissive Rosenpass."
-                write_result true "strict Rosenpass unverified ($RP_WHY); reverted to permissive"
-            fi
-        fi
-    fi
+    rosenpass_guard "$UP_ARGS"
+    case $? in
+        0) write_result true  "$RP_GUARD_MSG" ;;
+        1) write_result true  "$RP_GUARD_MSG" ;;
+        *) write_result false "$RP_GUARD_MSG" ;;
+    esac
 elif [ "$RC" -eq 124 ]; then
     log "netbird up timed out for profile '$PROFILE' after 90s."
     write_result false "timed out connecting (check management URL / setup key)"

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -281,7 +281,6 @@ else
     fi
 fi
 
-
 log "Running: netbird up (profile '$PROFILE', mode '$MODE')"
 OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
 RC=$?

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -257,6 +257,36 @@ else
     fi
 fi
 
+# Peer handshake census, used to tell a live data plane from a dead one. Prints
+# "<peers> <with-a-completed-handshake>". NetBird zeroes the handshake timestamp
+# (0001-01-01) until a peer actually completes one, while still reporting the
+# peer as "Connected", so this is the only honest liveness signal available.
+nb_handshake_stats() {
+    "$NB" status --json 2>/dev/null \
+        | grep -o '"lastWireguardHandshake":"[^"]*"' \
+        | awk '{t++} $0 !~ /0001-01-01/ {l++} END{printf "%d %d\n", t+0, l+0}'
+}
+
+# Commit-confirm for strict Rosenpass, in the spirit of a router's "reload in 5".
+# Strict mode refuses the WireGuard handshake with every peer that doesn't also
+# run Rosenpass, which can strand a headless Unraid host -- and because the
+# setting lives on flash, a reboot re-arms it rather than recovering. So verify
+# the data plane really came back; 0 means it did (or there was nothing to
+# verify), 1 means no peer got through.
+rosenpass_commit_confirm() {
+    _rp_deadline=$(( $(date +%s) + 30 ))
+    while :; do
+        set -- $(nb_handshake_stats)
+        _rp_peers="${1:-0}"
+        _rp_live="${2:-0}"
+        # A single-peer network has nothing to handshake with; don't punish it.
+        [ "$_rp_peers" -eq 0 ] && return 0
+        [ "$_rp_live" -gt 0 ]  && return 0
+        [ "$(date +%s)" -ge "$_rp_deadline" ] && return 1
+        sleep 5
+    done
+}
+
 log "Running: netbird up (profile '$PROFILE', mode '$MODE')"
 OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
 RC=$?
@@ -264,7 +294,32 @@ echo "$OUT" >> /var/log/netbird-utils.log
 if [ "$RC" -eq 0 ]; then
     log "netbird up succeeded for profile '$PROFILE'."
     reload_nginx_when_wt0_ready
-    write_result true "connected"
+    if [ "$ENABLE_ROSENPASS" = "1" ] && ! rosenpass_commit_confirm; then
+        log "Strict Rosenpass: no peer completed a handshake within 30s; reverting to permissive."
+        # Persist the safer value first, so a reboot can't re-arm the lockout even
+        # if the reconnect below fails. The key may be absent on an upgrade.
+        if grep -q '^ENABLE_ROSENPASS=' "$GLOBAL_CFG" 2>/dev/null; then
+            sed -i 's/^ENABLE_ROSENPASS=.*/ENABLE_ROSENPASS="permissive"/' "$GLOBAL_CFG"
+        else
+            echo 'ENABLE_ROSENPASS="permissive"' >> "$GLOBAL_CFG"
+        fi
+        UP_ARGS=$(printf '%s' "$UP_ARGS" | sed 's/--rosenpass-permissive=false/--rosenpass-permissive=true/')
+        # `down` first: a plain `up` on a live profile is a no-op, so the engine
+        # would never pick the changed flag up (same reason 'reconnect' exists).
+        "$NB" down >/dev/null 2>&1
+        OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
+        RC=$?
+        echo "$OUT" >> /var/log/netbird-utils.log
+        if [ "$RC" -eq 0 ]; then
+            log "Reconnected with permissive Rosenpass."
+            write_result true "strict Rosenpass reached no peers; reverted to permissive"
+        else
+            log "Permissive Rosenpass reconnect failed (rc=$RC): $OUT"
+            write_result false "strict Rosenpass reached no peers; permissive retry failed (rc=$RC)"
+        fi
+    else
+        write_result true "connected"
+    fi
 elif [ "$RC" -eq 124 ]; then
     log "netbird up timed out for profile '$PROFILE' after 90s."
     write_result false "timed out connecting (check management URL / setup key)"

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -262,29 +262,59 @@ fi
 # (0001-01-01) until a peer actually completes one, while still reporting the
 # peer as "Connected", so this is the only honest liveness signal available.
 nb_handshake_stats() {
-    "$NB" status --json 2>/dev/null \
+    _hs_out=$("$NB" status --json 2>/dev/null) || return 1
+    [ -n "$_hs_out" ] || return 1
+    # Shape check only: a truncated or plain-text reply must not reach the
+    # counter, where it would read as "no peers".
+    case "$_hs_out" in '{'*'}') ;; *) return 1 ;; esac
+    case "$_hs_out" in *'"peers"'*) ;; *) return 1 ;; esac
+    printf '%s\n' "$_hs_out" \
         | grep -o '"lastWireguardHandshake":"[^"]*"' \
         | awk '{t++} $0 !~ /0001-01-01/ {l++} END{printf "%d %d\n", t+0, l+0}'
 }
 
-# Commit-confirm for strict Rosenpass, in the spirit of a router's "reload in 5".
-# Strict mode refuses the WireGuard handshake with every peer that doesn't also
-# run Rosenpass, which can strand a headless Unraid host -- and because the
-# setting lives on flash, a reboot re-arms it rather than recovering. So verify
-# the data plane really came back; 0 means it did (or there was nothing to
-# verify), 1 means no peer got through.
+# Write permissive, then read it back: a failed sed or read-only /boot must not
+# be reported as a durable revert.
+nb_persist_rosenpass_permissive() {
+    if grep -q '^ENABLE_ROSENPASS=' "$GLOBAL_CFG" 2>/dev/null; then
+        sed -i 's/^ENABLE_ROSENPASS=.*/ENABLE_ROSENPASS="permissive"/' "$GLOBAL_CFG" || return 1
+    else
+        # Without a trailing newline the key would glue onto the last line.
+        if [ -s "$GLOBAL_CFG" ] && [ -n "$(tail -c 1 "$GLOBAL_CFG")" ]; then
+            printf '\n' >> "$GLOBAL_CFG" || return 1
+        fi
+        printf 'ENABLE_ROSENPASS="permissive"\n' >> "$GLOBAL_CFG" || return 1
+    fi
+    grep -q '^ENABLE_ROSENPASS="permissive"$' "$GLOBAL_CFG" 2>/dev/null
+}
+
+nb_live_rosenpass_permissive() {
+    "$NB" status 2>/dev/null | grep -qi 'quantum resistance.*permissive'
+}
+
+# Commit-confirm for strict Rosenpass, like a router's "reload in 5": strict
+# refuses peers that don't run it and the setting survives a reboot, so prove the
+# data plane works before leaving it armed. 0 = keep strict (a handshake landed,
+# or no peers for the whole window), 1 = peers but no handshake, 2 = status
+# unreadable. Non-zero reverts; "unknown" must not read as "fine". Zero peers is
+# only believed if it holds all window, since the list is empty just after `up`.
 rosenpass_commit_confirm() {
     _rp_deadline=$(( $(date +%s) + 30 ))
+    _rp_saw_status=0
+    _rp_saw_peers=0
     while :; do
-        set -- $(nb_handshake_stats)
-        _rp_peers="${1:-0}"
-        _rp_live="${2:-0}"
-        # A single-peer network has nothing to handshake with; don't punish it.
-        [ "$_rp_peers" -eq 0 ] && return 0
-        [ "$_rp_live" -gt 0 ]  && return 0
-        [ "$(date +%s)" -ge "$_rp_deadline" ] && return 1
+        if _rp_census=$(nb_handshake_stats); then
+            _rp_saw_status=1
+            set -- $_rp_census
+            [ "${1:-0}" -gt 0 ] && _rp_saw_peers=1
+            [ "${2:-0}" -gt 0 ] && return 0
+        fi
+        [ "$(date +%s)" -ge "$_rp_deadline" ] && break
         sleep 5
     done
+    [ "$_rp_saw_status" -eq 0 ] && return 2
+    [ "$_rp_saw_peers" -eq 1 ] && return 1
+    return 0
 }
 
 log "Running: netbird up (profile '$PROFILE', mode '$MODE')"
@@ -294,31 +324,44 @@ echo "$OUT" >> /var/log/netbird-utils.log
 if [ "$RC" -eq 0 ]; then
     log "netbird up succeeded for profile '$PROFILE'."
     reload_nginx_when_wt0_ready
-    if [ "$ENABLE_ROSENPASS" = "1" ] && ! rosenpass_commit_confirm; then
-        log "Strict Rosenpass: no peer completed a handshake within 30s; reverting to permissive."
-        # Persist the safer value first, so a reboot can't re-arm the lockout even
-        # if the reconnect below fails. The key may be absent on an upgrade.
-        if grep -q '^ENABLE_ROSENPASS=' "$GLOBAL_CFG" 2>/dev/null; then
-            sed -i 's/^ENABLE_ROSENPASS=.*/ENABLE_ROSENPASS="permissive"/' "$GLOBAL_CFG"
-        else
-            echo 'ENABLE_ROSENPASS="permissive"' >> "$GLOBAL_CFG"
-        fi
-        UP_ARGS=$(printf '%s' "$UP_ARGS" | sed 's/--rosenpass-permissive=false/--rosenpass-permissive=true/')
-        # `down` first: a plain `up` on a live profile is a no-op, so the engine
-        # would never pick the changed flag up (same reason 'reconnect' exists).
-        "$NB" down >/dev/null 2>&1
-        OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
-        RC=$?
-        echo "$OUT" >> /var/log/netbird-utils.log
-        if [ "$RC" -eq 0 ]; then
-            log "Reconnected with permissive Rosenpass."
-            write_result true "strict Rosenpass reached no peers; reverted to permissive"
-        else
-            log "Permissive Rosenpass reconnect failed (rc=$RC): $OUT"
-            write_result false "strict Rosenpass reached no peers; permissive retry failed (rc=$RC)"
-        fi
-    else
+    RP_CONFIRM=0
+    if [ "$ENABLE_ROSENPASS" = "1" ]; then
+        rosenpass_commit_confirm
+        RP_CONFIRM=$?
+    fi
+    if [ "$RP_CONFIRM" -eq 0 ]; then
         write_result true "connected"
+    else
+        if [ "$RP_CONFIRM" -eq 1 ]; then
+            RP_WHY="no peer completed a handshake"
+        else
+            RP_WHY="peer status was unreadable"
+        fi
+        log "Strict Rosenpass: $RP_WHY within 30s; reverting to permissive."
+        # Persist the safer value first so a reboot can't re-arm the lockout.
+        if ! nb_persist_rosenpass_permissive; then
+            log "ERROR: could not write ENABLE_ROSENPASS=permissive to $GLOBAL_CFG; strict stays armed for the next boot."
+            write_result false "strict Rosenpass unverified ($RP_WHY) and the permissive fallback could not be saved"
+        else
+            UP_ARGS=$(printf '%s' "$UP_ARGS" | sed 's/--rosenpass-permissive=false/--rosenpass-permissive=true/')
+            # `down` first: `up` on a live profile is a no-op (see 'reconnect').
+            if ! "$NB" down >/dev/null 2>&1; then
+                log "WARN: netbird down failed before the permissive retry; the following up may be a no-op."
+            fi
+            OUT=$(timeout 90 "$NB" $UP_ARGS 2>&1)
+            RC=$?
+            echo "$OUT" >> /var/log/netbird-utils.log
+            if [ "$RC" -ne 0 ]; then
+                log "Permissive Rosenpass reconnect failed (rc=$RC): $OUT"
+                write_result false "strict Rosenpass unverified ($RP_WHY); permissive retry failed (rc=$RC)"
+            elif ! nb_live_rosenpass_permissive; then
+                log "Permissive reconnect returned success but the daemon is not in permissive mode."
+                write_result false "strict Rosenpass unverified ($RP_WHY); permissive is not in effect"
+            else
+                log "Reconnected with permissive Rosenpass."
+                write_result true "strict Rosenpass unverified ($RP_WHY); reverted to permissive"
+            fi
+        fi
     fi
 elif [ "$RC" -eq 124 ]; then
     log "netbird up timed out for profile '$PROFILE' after 90s."

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -25,12 +25,23 @@
 
 . /usr/local/emhttp/plugins/netbird/include/log.sh 2>/dev/null || log() { echo "$*" ; }
 # Strict-Rosenpass safety net, shared with the watchdog the Connect / profile
-# switch / boot paths fire. Without it we still connect, but unverified.
+# switch / boot paths fire. If it's missing we refuse to arm strict at all (see
+# the ENABLE_ROSENPASS case below) rather than connect in the one mode that can
+# strand this host with nothing able to undo it.
+RP_GUARD_OK=0
 if [ -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ]; then
     . /usr/local/emhttp/plugins/netbird/include/rosenpass.sh
+    RP_GUARD_OK=1
 else
-    log "WARN: include/rosenpass.sh missing; strict Rosenpass will not be verified."
-    rosenpass_guard() { RP_GUARD_MSG="connected"; return 0; }
+    log "WARN: include/rosenpass.sh missing; strict Rosenpass will be downgraded to permissive."
+    rosenpass_guard() {
+        if [ "${ENABLE_ROSENPASS:-0}" = "1" ]; then
+            RP_GUARD_MSG="connected permissively; strict not armed because verification is unavailable"
+        else
+            RP_GUARD_MSG="connected"
+        fi
+        return 0
+    }
 fi
 
 PROFILE="$1"
@@ -211,7 +222,12 @@ UP_ARGS="up"
 # Explicit booleans either way so toggling off actually disables it — NetBird
 # remembers the last flag value on the profile otherwise (same as --disable-dns).
 case "$ENABLE_ROSENPASS" in
-    1)          UP_ARGS="$UP_ARGS --enable-rosenpass=true --rosenpass-permissive=false" ;;
+    1)          if [ "$RP_GUARD_OK" = "1" ]; then
+                    UP_ARGS="$UP_ARGS --enable-rosenpass=true --rosenpass-permissive=false"
+                else
+                    # No guard to recover a lockout, so don't create one.
+                    UP_ARGS="$UP_ARGS --enable-rosenpass=true --rosenpass-permissive=true"
+                fi ;;
     permissive) UP_ARGS="$UP_ARGS --enable-rosenpass=true --rosenpass-permissive=true" ;;
     *)          UP_ARGS="$UP_ARGS --enable-rosenpass=false --rosenpass-permissive=false" ;;
 esac

--- a/src/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Verify a strict-Rosenpass connection really carries traffic, and fall back to
+# permissive if it doesn't. Fired by the paths that connect without going
+# through apply.sh: the Connect action, profile switching, and daemon start at
+# boot or array start.
+#
+# Usage: rosenpass-watchdog.sh [initial-delay-seconds] [window-seconds]
+# Boot needs a longer window than a warm reconnect, since peers must reach
+# management and re-establish before any handshake can land.
+
+DELAY="${1:-0}"
+RP_CONFIRM_WINDOW="${2:-30}"
+export RP_CONFIRM_WINDOW
+
+NB=/usr/local/sbin/netbird
+DEFAULT_CFG=/usr/local/emhttp/plugins/netbird/default.cfg
+GLOBAL_CFG=/boot/config/plugins/netbird/netbird.cfg
+LOCK_FILE=/var/run/netbird-apply.lock
+
+. /usr/local/emhttp/plugins/netbird/include/log.sh 2>/dev/null || log() { echo "$*" ; }
+[ -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ] || exit 0
+. /usr/local/emhttp/plugins/netbird/include/rosenpass.sh
+
+[ "$DELAY" -gt 0 ] 2>/dev/null && sleep "$DELAY"
+
+[ -f "$DEFAULT_CFG" ] && . "$DEFAULT_CFG"
+[ -f "$GLOBAL_CFG" ]  && . "$GLOBAL_CFG"
+
+# Nothing to guard unless the daemon is meant to be up and strict is armed.
+[ "${ENABLE_NETBIRD:-0}" = "1" ]   || exit 0
+[ "${ENABLE_ROSENPASS:-0}" = "1" ] || exit 0
+
+# Serialize against apply.sh: if an apply holds the lock it runs this same check
+# itself, so there is nothing for us to do.
+exec 9>"$LOCK_FILE"
+flock -n 9 || exit 0
+
+rosenpass_guard
+log "rosenpass watchdog: $RP_GUARD_MSG"

--- a/src/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh
@@ -8,6 +8,11 @@
 # Boot needs a longer window than a warm reconnect, since peers must reach
 # management and re-establish before any handshake can land.
 
+# Invoked both from php-fpm and from rc.netbird at boot, so don't assume either
+# hands us a usable PATH -- rc.netbird hardcodes /usr/bin/flock for this reason.
+PATH=/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin
+export PATH
+
 DELAY="${1:-0}"
 RP_CONFIRM_WINDOW="${2:-30}"
 export RP_CONFIRM_WINDOW
@@ -18,8 +23,6 @@ GLOBAL_CFG=/boot/config/plugins/netbird/netbird.cfg
 LOCK_FILE=/var/run/netbird-apply.lock
 
 . /usr/local/emhttp/plugins/netbird/include/log.sh 2>/dev/null || log() { echo "$*" ; }
-[ -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ] || exit 0
-. /usr/local/emhttp/plugins/netbird/include/rosenpass.sh
 
 [ "$DELAY" -gt 0 ] 2>/dev/null && sleep "$DELAY"
 
@@ -29,6 +32,14 @@ LOCK_FILE=/var/run/netbird-apply.lock
 # Nothing to guard unless the daemon is meant to be up and strict is armed.
 [ "${ENABLE_NETBIRD:-0}" = "1" ]   || exit 0
 [ "${ENABLE_ROSENPASS:-0}" = "1" ] || exit 0
+
+# Strict is armed and we were asked to verify it. Without the shared logic we
+# cannot, so say so loudly instead of exiting as if all were well.
+if [ ! -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ]; then
+    log "ERROR: strict Rosenpass is armed but include/rosenpass.sh is missing; connectivity is unverified."
+    exit 1
+fi
+. /usr/local/emhttp/plugins/netbird/include/rosenpass.sh
 
 # Serialize against apply.sh: if an apply holds the lock it runs this same check
 # itself, so there is nothing for us to do.

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -125,8 +125,12 @@ start_netbird() {
         # no `up` here to hook, so strict Rosenpass would go unverified. Longer
         # window than a warm reconnect: peers need time to re-establish. 9>&- so
         # this doesn't inherit the rc lock descriptor.
-        ( /usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh 30 180 ) \
-            >/dev/null 2>&1 </dev/null 9>&- &
+        if [ -x /usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh ]; then
+            ( /usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh 30 180 ) \
+                >/dev/null 2>&1 </dev/null 9>&- &
+        else
+            log "WARN: rosenpass watchdog missing; a strict Rosenpass profile will come up unverified."
+        fi
         log "NetBird daemon socket is up."
         return 0
     fi

--- a/src/usr/local/etc/rc.d/rc.netbird
+++ b/src/usr/local/etc/rc.d/rc.netbird
@@ -121,6 +121,12 @@ start_netbird() {
             # descriptor and extend the lock ~2s past our own exit.
             ( sleep 2; chmod 600 "$HTTPSOCKFILE" 2>/dev/null ) >/dev/null 2>&1 </dev/null 9>&- &
         fi
+        # Boot and array start connect from the profile's persisted config, with
+        # no `up` here to hook, so strict Rosenpass would go unverified. Longer
+        # window than a warm reconnect: peers need time to re-establish. 9>&- so
+        # this doesn't inherit the rc lock descriptor.
+        ( /usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh 30 180 ) \
+            >/dev/null 2>&1 </dev/null 9>&- &
         log "NetBird daemon socket is up."
         return 0
     fi


### PR DESCRIPTION
## Description

Follow-up to #43 (`feat: add rosenpass toggle`, merged as c396987), which added the `ENABLE_ROSENPASS` setting. The plumbing in that PR is correct and unchanged here. This adds guardrails around strict mode.


<img width="1344" height="789" alt="Screenshot 2026-08-24 at 12 04 53 AM" src="https://github.com/user-attachments/assets/79ad6dc2-b1c4-4109-91ba-90bd2028e0b3" />

Strict Rosenpass refuses the WireGuard handshake with any peer that doesn't also run it. On Unraid the host is usually a routing peer or exit node, so picking strict from the dropdown can strand the machine you're configuring. Every peer without Rosenpass loses the host, including the browser applying the change if it reaches Unraid over NetBird, which leaves the Apply screen hanging. NetBird still reports those peers as `Connected` and only `lastWireguardHandshake` stays at its zero value, so the Status page showed a healthy tunnel that carried no traffic. `ENABLE_ROSENPASS` is written to flash before `apply.sh` runs and the daemon auto-connects from persisted profile config, so a reboot doesn't clear it. Getting back in requires another peer with Rosenpass enabled, or physical access.

We hit this on a live host while reviewing #43. One dropdown change cut off SSH, the web UI, and the exit node the admin's laptop was routing through, and recovery meant enabling permissive Rosenpass on another peer.

Rosenpass is negotiated per pair of peers and is client-side only; management stores it as reported peer metadata and there's no network-wide switch in the dashboard. Strict only makes sense once every relevant peer already runs it, so permissive is the right default for almost any Unraid install.

## Changes

`include/status_view.php` — The Rosenpass row distinguishes `(strict)` from `(permissive)` instead of just saying "Enabled", and turns red with an explanation when Rosenpass is strict, peers report connected, and none has completed a handshake. It reads the per-peer `lastWireguardHandshake` that `common.php` already normalizes and the peers table already renders, so there's no new data plumbing. The warning is scoped to strict mode so a stall from an unrelated cause isn't blamed on Rosenpass.

`Netbird-1-Settings.page` — Options reordered and relabelled to `No` / `Yes (permissive, recommended)` / `Yes (strict)`. Stored values are unchanged, so there's no migration. The help text now notes that upstream marks the feature experimental, that both ends need it before a link is protected, and what strict costs.

`Netbird-1-Settings.page` — Applying strict now goes through a `swal` confirm that names the consequences: peers cut off, still shown as "Connected", survives reboot, recovery needs another Rosenpass peer. It follows the existing delete-profile confirm and fires only on the transition into strict, so applying unrelated settings doesn't trigger it. The POST body moved into `nbPostSettings(profile, data)` so the confirm can gate it. `nbProfile()` is byte-identical to `main`.

`include/rosenpass.sh` (new) — The safety net itself, in a sourceable file so every path that can bring a profile up gets the same verification. `rosenpass_commit_confirm()` polls after an `up` with strict armed and returns one of three outcomes: keep strict (a peer completed a handshake, or no peers were ever seen across the whole window), peers present but no handshake, or status unreadable. Both non-zero outcomes fall back to permissive, so an unknown state is treated as a revert rather than a pass — the states we can't read are exactly the ones a lockout produces. The window is configurable via `RP_CONFIRM_WINDOW`, since a cold boot needs longer than a warm reconnect.

`nb_handshake_stats()` reports the peer census, and returns failure rather than a count when `netbird status --json` exits non-zero, returns nothing, or returns something that isn't a complete JSON object with a `peers` key. That matters because a failed, empty or truncated response otherwise counts zero handshakes and reads identically to a genuinely empty network, which is the reading that would let a lockout stand. A zero-peer result is only believed if it holds for the entire window, since the peer list is briefly empty right after `up`.

The rollback checks every step. `nb_persist_rosenpass_permissive()` writes `permissive` to `netbird.cfg` and reads it back, so a failed `sed` or an unwritable `/boot` is reported honestly instead of claiming a durable revert that would leave strict armed for the next boot; it also handles a cfg with no trailing newline, which would otherwise glue the key onto the last line and break both shell sourcing and ini parsing. `netbird down`'s exit status is checked and logged, because a `down` that didn't take makes the following `up` a no-op that would otherwise be reported as a successful permissive reconnect. Finally `nb_live_rosenpass_permissive()` confirms the daemon actually ended up permissive before the result says so. `rosenpass_guard()` wraps the whole flow and hands the caller a message to report.

`scripts/rosenpass-watchdog.sh` (new) — Standalone entry point for the paths that connect without running `apply.sh`. Takes an initial delay and a window, no-ops unless NetBird is enabled and strict is armed, and takes the apply lock with `flock -n` so it steps aside when an apply is already running the same check. It pins `PATH`, because it is invoked both from php-fpm and from `rc.netbird` at boot and neither is guaranteed to supply a usable one — `rc.netbird` hardcodes `/usr/bin/flock` for the same reason.

`scripts/apply.sh` — Sources the shared include and calls `rosenpass_guard "$UP_ARGS"`, mapping the outcome onto `write_result` so the Settings page reports what actually happened. If the include is ever missing it logs a warning and connects unverified rather than failing the apply.

`include/action.php` — Fires the watchdog after a successful `up` in both the Connect action and profile selection, via a small helper that no-ops unless strict is armed. It runs after the lock is released, since both share `/var/run/netbird-apply.lock`. The callers only trigger the check, so the credential handling that keeps profiles from crossing is untouched.

`usr/local/etc/rc.d/rc.netbird` — Fires the watchdog once the daemon socket is up, with a longer delay and window than a warm reconnect because peers have to reach management and re-establish first. Boot and array start connect from the profile's persisted config with no `up` to hook, so this is the only place to catch a strict setting that survived a reboot. Uses the file's existing `9>&-` pattern so it doesn't hold the rc lock.

Also restored the trailing newline `apply.sh` lost in #43, and fixed the docs link from `/how-to/enable-post-quantum-cryptography` to `https://docs.netbird.io/client/post-quantum-cryptography`.

## Testing

Verified on Unraid 7.3.2, NetBird 0.77.0, PHP 8.4.23, with a package built from this branch installed.

- Manual navigation and validation of new UI components and settings.
- `php -l` clean on the changed PHP, `sh -n` / `bash -n` clean on all four shell files, and the page's JS passes `node --check` with the PHP tags stubbed out.
- Status page logic, 8/8 synthetic cases: strict and stalled, strict and healthy, permissive and stalled, Rosenpass off, zero peers, only `Connecting` peers, a `Connecting` peer holding the sole live handshake, and a missing handshake key.
- Rosenpass logic, 33/33 against a stubbed `netbird` on the box itself so Slackware's `grep`, `awk` and GNU `sed -i` are covered, with a stubbed clock for the timeout path. Both the helpers and the real success branch are extracted verbatim from source rather than reimplemented in the harness.
- Census cases: valid zero-peer, peers with zero timestamps, one completed handshake, status exits non-zero, status returns empty, truncated JSON, and a plain-text daemon message. The last four must report failure, not a zero count.
- Confirm cases: each of the above, plus zero-peers-then-peers-without-a-handshake and zero-peers-then-a-handshake, to cover settling.
- Rollback cases: cfg write failure (tested with an unwritable path, since the script runs as root and ignores permission bits), `down` failure, permissive retry failure, and a successful `up` where the daemon is still strict. Each reports its own distinct result instead of a generic success.
- Guard gating: no-ops without querying the daemon at all when strict isn't armed, and a stub that only goes live on the fifth poll reverts under a short window but confirms under a longer one, exercising `RP_CONFIRM_WINDOW`.
- Watchdog behavior on the live host: no-ops immediately when strict is off, confirms without reverting when strict with a healthy daemon, steps aside when the apply lock is held, and still resolves its tools and config when run under `env -i` with an empty environment.
- All three settings values end to end through `apply.sh` on the live host. Off applies clean with no confirm fired, permissive applies clean, and strict with a Rosenpass-capable peer present waits out part of the window, stays armed, and reports `connected` with no false revert.
- Config rewrite both ways: an existing key is rewritten in place, a missing key (pre-upgrade cfg) is appended, unrelated keys survive, a cfg with no trailing newline isn't corrupted, and the result still parses as ini.
- `nbProfile()` byte-identical to `main`, with every JS entry point defined once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear distinction between permissive and strict Rosenpass modes.
  - Added confirmation and connectivity-risk guidance when switching to strict mode.
  - Added status indicators for peer connectivity and completed WireGuard handshakes.
  - Added background monitoring after startup and profile changes to verify strict-mode connectivity.

- **Bug Fixes**
  - Strict mode now detects stalled connections and displays remediation guidance.
  - If strict mode cannot establish a handshake, the connection automatically falls back to permissive mode and reports the recovery result.
  - Added startup warnings when strict-mode verification is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

