### PR TITLE
chore: update NetBird to 0.78.1

### DIFF
--- a/plugin/netbird.plg
+++ b/plugin/netbird.plg
@@ -11,10 +11,10 @@
 <!ENTITY emhttpLOC   "/usr/local/emhttp/plugins/&name;">
 
 <!-- NetBird upstream binary -->
-<!ENTITY netbirdVer    "0.77.1">
+<!ENTITY netbirdVer    "0.78.1">
 <!ENTITY netbirdFile   "netbird_&netbirdVer;_linux_amd64.tar.gz">
 <!ENTITY netbirdURL    "https://github.com/netbirdio/netbird/releases/download/v&netbirdVer;/&netbirdFile;">
-<!ENTITY netbirdSHA256 "c4e819ccd0337a73f6d9f42723728201c114bc64b9d735d55ae967ad7f4265d4">
+<!ENTITY netbirdSHA256 "9239c9e37c2acc0612563ef5ce0c3326397460d0eb811b5a59a8e373f1a4ebde">
 
 <!-- Plugin support package (built from src/) -->
 <!ENTITY pkgName       "unraid-netbird-utils">

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -6,6 +6,6 @@
   "min": "7.0.0",
   "support": "https://github.com/netbirdio/netbird-unraid/issues",
   "launch": "Settings/Netbird",
-  "netbirdVersion": "0.77.1",
-  "netbirdSHA256": "c4e819ccd0337a73f6d9f42723728201c114bc64b9d735d55ae967ad7f4265d4"
+  "netbirdVersion": "0.78.1",
+  "netbirdSHA256": "9239c9e37c2acc0612563ef5ce0c3326397460d0eb811b5a59a8e373f1a4ebde"
 }


### PR DESCRIPTION
Automated upstream bump: NetBird `0.78.1` (version + SHA256 verified against netbirdio/netbird).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled NetBird release from version 0.77.1 to 0.78.1.
  * Updated the associated download verification information for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->