### PR TITLE
fix: validate Rosenpass handshakes before keeping strict mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,18 @@ on:
   pull_request:
 
 jobs:
+  rosenpass-tests:
+    name: Rosenpass regression tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Exercise the guard and status parser
+        run: |
+          docker run --rm --network none \
+            -v "$GITHUB_WORKSPACE:/work:ro" \
+            -v "$GITHUB_WORKSPACE/src/usr/local/emhttp/plugins/netbird:/usr/local/emhttp/plugins/netbird:ro" \
+            -w /work php:8.2-cli php tests/rosenpass-test.php
+
   php-cs-fixer:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest

--- a/src/usr/local/emhttp/plugins/netbird/include/action.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/action.php
@@ -159,14 +159,13 @@ function nb_up_args(array $creds): array
 const NB_ROSENPASS_WATCHDOG = '/usr/local/emhttp/plugins/netbird/scripts/rosenpass-watchdog.sh';
 
 /**
- * Whether the strict-Rosenpass safety net is installed and usable. Both halves
- * are needed: the watchdog script to run the check, and the shared guard it
- * sources to perform it.
+ * Whether the strict-Rosenpass watchdog, guard, and status parser are installed.
  */
 function nb_rosenpass_guard_available(): bool
 {
     return is_executable(NB_ROSENPASS_WATCHDOG)
-        && is_readable('/usr/local/emhttp/plugins/netbird/include/rosenpass.sh');
+        && is_readable('/usr/local/emhttp/plugins/netbird/include/rosenpass.sh')
+        && is_readable('/usr/local/emhttp/plugins/netbird/include/handshake.php');
 }
 
 /**

--- a/src/usr/local/emhttp/plugins/netbird/include/common.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/common.php
@@ -5,6 +5,8 @@
 
 namespace Netbird;
 
+require_once __DIR__ . '/handshake.php';
+
 const PLUGIN          = 'netbird';
 const NETBIRD_BIN     = '/usr/local/sbin/netbird';
 const RC_SCRIPT       = '/etc/rc.d/rc.netbird';
@@ -174,10 +176,7 @@ function pbDurationNs(mixed $dur): int
  */
 function pbTimestamp(?string $ts): ?string
 {
-    if (!$ts || str_starts_with($ts, '1970-01-01') || str_starts_with($ts, '0001-01-01')) {
-        return null;
-    }
-    return $ts;
+    return handshakeTime($ts) === null ? null : $ts;
 }
 
 /**
@@ -222,6 +221,7 @@ function mapGatewayStatus(array $resp, string $profileName): array
             'relayAddress'     => $isConn ? ($p['relayAddress'] ?? '') : '',
             'latency'          => pbDurationNs($p['latency'] ?? null),
             'lastWireguardHandshake' => $isConn ? pbTimestamp($p['lastWireguardHandshake'] ?? null) : null,
+            'quantumResistance' => !empty($p['rosenpassEnabled']),
             // int64 arrives as a JSON string per the protobuf JSON mapping.
             'transferReceived' => $isConn ? (int) ($p['bytesRx'] ?? 0) : 0,
             'transferSent'     => $isConn ? (int) ($p['bytesTx'] ?? 0) : 0,
@@ -627,11 +627,8 @@ function humanBytes(int $bytes): string
  */
 function relativeTime(?string $iso): string
 {
-    if (!$iso || str_starts_with($iso, '0001-01-01')) {
-        return '-';
-    }
-    $ts = strtotime($iso);
-    if ($ts === false) {
+    $ts = handshakeTime($iso);
+    if ($ts === null) {
         return '-';
     }
     $delta = time() - $ts;

--- a/src/usr/local/emhttp/plugins/netbird/include/handshake.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/handshake.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Netbird;
+
+/**
+ * Parse a handshake timestamp, rejecting unset times regardless of timezone.
+ */
+function handshakeTime(mixed $value): ?int
+{
+    if (!is_string($value) || !preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/D', $value)) {
+        return null;
+    }
+    // Go emits nanoseconds; second precision is enough for the liveness check.
+    $value = preg_replace('/\.\d+/', '', $value);
+    $date = \DateTimeImmutable::createFromFormat('!Y-m-d\TH:i:sP', $value);
+    $errors = \DateTimeImmutable::getLastErrors();
+    if ($date === false || ($errors !== false && ($errors['warning_count'] || $errors['error_count']))) {
+        return null;
+    }
+    $time = $date->getTimestamp();
+    return $time > 0 ? $time : null;
+}
+
+/**
+ * Whether a connected Rosenpass peer has a recent WireGuard handshake.
+ *
+ * @param array<string,mixed> $peer
+ */
+function hasRosenpassHandshake(array $peer, ?int $now = null): bool
+{
+    if (($peer['status'] ?? '') !== 'Connected' || ($peer['quantumResistance'] ?? false) !== true) {
+        return false;
+    }
+    $handshake = handshakeTime($peer['lastWireguardHandshake'] ?? null);
+    $now = $now ?? time();
+    // Match NetBird's WireGuard watcher: three minutes plus 30 seconds grace.
+    return $handshake !== null && $handshake <= $now && $handshake >= $now - 210;
+}
+
+/**
+ * Count peers and healthy handshakes without treating malformed status as empty.
+ *
+ * @return array{int,int}
+ */
+function handshakeStats(\stdClass $status): array
+{
+    $peers = $status->peers ?? null;
+    if (!$peers instanceof \stdClass || !is_int($peers->total ?? null) || !property_exists($peers, 'details')) {
+        throw new \UnexpectedValueException('Missing peer status');
+    }
+    // A nil Go slice is encoded as null when there are no peers.
+    $details = $peers->details ?? [];
+    if (!is_array($details) || count($details) !== $peers->total) {
+        throw new \UnexpectedValueException('Incomplete peer status');
+    }
+    $healthy = 0;
+    $now = time();
+    foreach ($details as $peer) {
+        if (!$peer instanceof \stdClass || !is_string($peer->status ?? null)) {
+            throw new \UnexpectedValueException('Invalid peer status');
+        }
+        if (hasRosenpassHandshake((array) $peer, $now)) {
+            $healthy++;
+        }
+    }
+    return [count($details), $healthy];
+}
+
+// The shell guard supplies CLI JSON on stdin. Including this file in the UI
+// only defines the shared timestamp and liveness helpers.
+if (PHP_SAPI === 'cli' && realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
+    try {
+        $status = json_decode(file_get_contents('php://stdin'), false, 512, JSON_THROW_ON_ERROR);
+        if (!$status instanceof \stdClass) {
+            throw new \UnexpectedValueException('Invalid status');
+        }
+        if (($argv[1] ?? '') === 'permissive') {
+            exit(($status->quantumResistance ?? false) === true && ($status->quantumResistancePermissive ?? false) === true ? 0 : 1);
+        }
+        [$peers, $healthy] = handshakeStats($status);
+        echo "$peers $healthy\n";
+    } catch (\Throwable $error) {
+        fwrite(STDERR, "Unreadable NetBird status\n");
+        exit(2);
+    }
+}

--- a/src/usr/local/emhttp/plugins/netbird/include/rosenpass.sh
+++ b/src/usr/local/emhttp/plugins/netbird/include/rosenpass.sh
@@ -6,20 +6,11 @@
 # instead of only the Settings save path. Callers need $NB, $GLOBAL_CFG,
 # $ENABLE_ROSENPASS and a log() function.
 
-# Peer handshake census, used to tell a live data plane from a dead one. Prints
-# "<peers> <with-a-completed-handshake>". NetBird zeroes the handshake timestamp
-# (0001-01-01) until a peer actually completes one, while still reporting the
-# peer as "Connected", so this is the only honest liveness signal available.
+# CLI timestamps use the host timezone, even for Go's zero time. Parse JSON
+# and dates instead of matching the UTC sentinel's literal date prefix.
 nb_handshake_stats() {
-    _hs_out=$("$NB" status --json 2>/dev/null) || return 1
-    [ -n "$_hs_out" ] || return 1
-    # Shape check only: a truncated or plain-text reply must not reach the
-    # counter, where it would read as "no peers".
-    case "$_hs_out" in '{'*'}') ;; *) return 1 ;; esac
-    case "$_hs_out" in *'"peers"'*) ;; *) return 1 ;; esac
-    printf '%s\n' "$_hs_out" \
-        | grep -o '"lastWireguardHandshake":"[^"]*"' \
-        | awk '{t++} $0 !~ /0001-01-01/ {l++} END{printf "%d %d\n", t+0, l+0}'
+    _hs_out=$(timeout -k 1 "${1:-3}" "$NB" status --json 2>/dev/null) || return 1
+    printf '%s\n' "$_hs_out" | php /usr/local/emhttp/plugins/netbird/include/handshake.php 2>/dev/null
 }
 
 # Write permissive, then read it back: a failed sed or read-only /boot must not
@@ -38,7 +29,8 @@ nb_persist_rosenpass_permissive() {
 }
 
 nb_live_rosenpass_permissive() {
-    "$NB" status 2>/dev/null | grep -qi 'quantum resistance.*permissive'
+    _hs_out=$(timeout -k 1 3 "$NB" status --json 2>/dev/null) || return 1
+    printf '%s\n' "$_hs_out" | php /usr/local/emhttp/plugins/netbird/include/handshake.php permissive 2>/dev/null
 }
 
 # Commit-confirm for strict Rosenpass, like a router's "reload in 5": strict
@@ -51,17 +43,27 @@ rosenpass_commit_confirm() {
     _rp_deadline=$(( $(date +%s) + ${RP_CONFIRM_WINDOW:-30} ))
     _rp_saw_status=0
     _rp_saw_peers=0
+    _rp_unreadable=0
     while :; do
-        if _rp_census=$(nb_handshake_stats); then
+        _rp_remaining=$(( _rp_deadline - $(date +%s) ))
+        _rp_probe=$_rp_remaining
+        [ "$_rp_probe" -gt 0 ] || _rp_probe=1
+        [ "$_rp_probe" -le 3 ] || _rp_probe=3
+        if _rp_census=$(nb_handshake_stats "$_rp_probe"); then
             _rp_saw_status=1
             set -- $_rp_census
             [ "${1:-0}" -gt 0 ] && _rp_saw_peers=1
             [ "${2:-0}" -gt 0 ] && return 0
+        else
+            _rp_unreadable=1
         fi
-        [ "$(date +%s)" -ge "$_rp_deadline" ] && break
-        sleep 5
+        _rp_remaining=$(( _rp_deadline - $(date +%s) ))
+        [ "$_rp_remaining" -gt 0 ] || break
+        [ "$_rp_remaining" -le 5 ] || _rp_remaining=5
+        sleep "$_rp_remaining"
     done
     [ "$_rp_saw_status" -eq 0 ] && return 2
+    [ "$_rp_unreadable" -eq 1 ] && return 2
     [ "$_rp_saw_peers" -eq 1 ] && return 1
     return 0
 }
@@ -79,7 +81,7 @@ rosenpass_guard() {
     _rp_rc=$?
     [ "$_rp_rc" -eq 0 ] && return 0
     if [ "$_rp_rc" -eq 1 ]; then
-        _rp_why="no peer completed a handshake"
+        _rp_why="no Rosenpass peer has a recent handshake"
     else
         _rp_why="peer status was unreadable"
     fi
@@ -95,10 +97,10 @@ rosenpass_guard() {
     _rp_args="${1:-up --enable-rosenpass=true --rosenpass-permissive=true}"
     _rp_args=$(printf '%s' "$_rp_args" | sed 's/--rosenpass-permissive=false/--rosenpass-permissive=true/')
     # `down` first: `up` on a live profile is a no-op (see 'reconnect').
-    if ! "$NB" down >/dev/null 2>&1; then
+    if ! timeout -k 1 30 "$NB" down >/dev/null 2>&1; then
         log "WARN: netbird down failed before the permissive retry; the following up may be a no-op."
     fi
-    _rp_out=$(timeout 90 "$NB" $_rp_args 2>&1)
+    _rp_out=$(timeout -k 1 90 "$NB" $_rp_args 2>&1)
     _rp_up=$?
     if [ "$_rp_up" -ne 0 ]; then
         log "Permissive Rosenpass reconnect failed (rc=$_rp_up): $_rp_out"

--- a/src/usr/local/emhttp/plugins/netbird/include/status_view.php
+++ b/src/usr/local/emhttp/plugins/netbird/include/status_view.php
@@ -18,7 +18,7 @@ $manageDns = ($cfg['MANAGE_DNS'] ?? '1') === '1';
 // NetBird still reports those peers as "Connected". That leaves a live-looking
 // tunnel carrying nothing, which is invisible unless we say so, and it can
 // strand a headless host (the setting persists on flash across reboots). Flag
-// the signature: Rosenpass strict, peers connected, not one handshake completed.
+// the signature: Rosenpass strict, peers connected, no recent Rosenpass handshake.
 $rpEnabled    = !empty($status['quantumResistance']);
 $rpPermissive = !empty($status['quantumResistancePermissive']);
 $rpConnected  = 0;
@@ -28,8 +28,7 @@ foreach (($status['peers']['details'] ?? []) as $rpPeer) {
         continue;
     }
     $rpConnected++;
-    $rpHs = (string) ($rpPeer['lastWireguardHandshake'] ?? '');
-    if ($rpHs !== '' && !str_starts_with($rpHs, '0001-01-01')) {
+    if (Netbird\hasRosenpassHandshake($rpPeer)) {
         $rpHandshaken++;
     }
 }

--- a/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
+++ b/src/usr/local/emhttp/plugins/netbird/scripts/apply.sh
@@ -29,11 +29,12 @@
 # the ENABLE_ROSENPASS case below) rather than connect in the one mode that can
 # strand this host with nothing able to undo it.
 RP_GUARD_OK=0
-if [ -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ]; then
+if [ -r /usr/local/emhttp/plugins/netbird/include/rosenpass.sh ] \
+    && [ -r /usr/local/emhttp/plugins/netbird/include/handshake.php ]; then
     . /usr/local/emhttp/plugins/netbird/include/rosenpass.sh
     RP_GUARD_OK=1
 else
-    log "WARN: include/rosenpass.sh missing; strict Rosenpass will be downgraded to permissive."
+    log "WARN: Rosenpass verification files missing; strict Rosenpass will be downgraded to permissive."
     rosenpass_guard() {
         if [ "${ENABLE_ROSENPASS:-0}" = "1" ]; then
             RP_GUARD_MSG="connected permissively; strict not armed because verification is unavailable"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+Run the Rosenpass regression tests from the repository root:
+
+```sh
+docker run --rm --network none \
+  -v "$PWD:/work:ro" \
+  -v "$PWD/src/usr/local/emhttp/plugins/netbird:/usr/local/emhttp/plugins/netbird:ro" \
+  -w /work php:8.2-cli php tests/rosenpass-test.php
+```
+
+The tests exercise the installed shell guard and PHP status helpers with a
+temporary fake NetBird CLI. They cover unset timestamps in different timezones,
+handshake freshness and peer capability, malformed responses, persistent
+fallback, and a hung status process. No host networking or real daemon is used.

--- a/tests/rosenpass-test.php
+++ b/tests/rosenpass-test.php
@@ -1,0 +1,163 @@
+<?php
+// Run with PHP 8.2+ and the plugin mounted at its installed path.
+// No daemon, root access, or host network changes are needed.
+$plugin = '/usr/local/emhttp/plugins/netbird';
+require_once $plugin . '/include/common.php';
+$tmp = sys_get_temp_dir() . '/netbird-guard-' . bin2hex(random_bytes(6));
+mkdir($tmp, 0700);
+register_shutdown_function(function () use ($tmp) {
+    foreach (glob($tmp . '/*') as $file) {
+        unlink($file);
+    }
+    rmdir($tmp);
+});
+
+file_put_contents($tmp . '/netbird', <<<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >> "$NB_TEST_CALLS"
+case "$1" in
+    status)
+        if [ "${NB_TEST_HANG_STATUS:-0}" = 1 ]; then
+            trap '' TERM
+            sleep 30
+        fi
+        if [ "$2" = --json ]; then
+            cat "$NB_TEST_STATUS"
+            if [ -n "${NB_TEST_SECOND_STATUS:-}" ]; then
+                printf '%s\n' "$NB_TEST_SECOND_STATUS" > "$NB_TEST_STATUS"
+            fi
+        elif grep -q '"quantumResistancePermissive":true' "$NB_TEST_STATUS"; then
+            echo 'Quantum resistance: true (permissive)'
+        else
+            echo 'Quantum resistance: true'
+        fi
+        ;;
+    down) exit 0 ;;
+    up) cp "$NB_TEST_AFTER_UP" "$NB_TEST_STATUS" ;;
+    *) exit 1 ;;
+esac
+SH
+);
+chmod($tmp . '/netbird', 0700);
+
+$failures = 0;
+$checks = 0;
+function check(string $name, mixed $actual, mixed $expected): void
+{
+    global $failures, $checks;
+    $checks++;
+    if ($actual !== $expected) {
+        $failures++;
+        echo "FAIL $name: expected " . json_encode($expected) . ', got ' . json_encode($actual) . "\n";
+    }
+}
+
+function peer(array $overrides = []): array
+{
+    return array_replace([
+        'status' => 'Connected',
+        'quantumResistance' => true,
+        'lastWireguardHandshake' => gmdate('Y-m-d\TH:i:s\Z'),
+    ], $overrides);
+}
+
+function status(array $peers, bool $permissive = false): string
+{
+    return json_encode([
+        'quantumResistance' => true,
+        'quantumResistancePermissive' => $permissive,
+        'peers' => ['total' => count($peers), 'details' => $peers],
+    ], JSON_THROW_ON_ERROR);
+}
+
+function runGuard(string $status, string $function = 'rosenpass_commit_confirm', array $extraEnv = []): array
+{
+    global $tmp, $plugin;
+    file_put_contents($tmp . '/status.json', $status);
+    file_put_contents($tmp . '/after-up.json', $extraEnv['NB_TEST_UP_STATUS'] ?? status([peer()], true));
+    file_put_contents($tmp . '/calls', '');
+    file_put_contents($tmp . '/netbird.cfg', "ENABLE_NETBIRD=\"1\"\nENABLE_ROSENPASS=\"1\"\n");
+    $env = array_merge(getenv(), [
+        'NB' => $tmp . '/netbird',
+        'GLOBAL_CFG' => $tmp . '/netbird.cfg',
+        'ENABLE_ROSENPASS' => '1',
+        'RP_CONFIRM_WINDOW' => '0',
+        'NB_TEST_STATUS' => $tmp . '/status.json',
+        'NB_TEST_AFTER_UP' => $tmp . '/after-up.json',
+        'NB_TEST_CALLS' => $tmp . '/calls',
+    ], $extraEnv);
+    $command = 'log() { :; }; . "$1"; ' . $function;
+    $start = microtime(true);
+    $process = proc_open(['timeout', '-k', '1', '8', 'sh', '-c', $command, 'guard-test', $plugin . '/include/rosenpass.sh'],
+        [0 => ['file', '/dev/null', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, null, $env);
+    $out = stream_get_contents($pipes[1]);
+    $err = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $rc = proc_close($process);
+    return [$rc, file_get_contents($tmp . '/netbird.cfg'), file_get_contents($tmp . '/calls'), microtime(true) - $start, $out, $err];
+}
+
+$cases = [
+    'UTC unset handshake' => [status([peer(['lastWireguardHandshake' => '0001-01-01T00:00:00Z'])]), 1],
+    'captured Los Angeles unset handshake' => [status([peer(['lastWireguardHandshake' => '0000-12-31T16:07:02-07:52'])]), 1],
+    'positive offset unset handshake' => [status([peer(['lastWireguardHandshake' => '0001-01-01T09:18:59+09:18'])]), 1],
+    'local Unix epoch' => [status([peer(['lastWireguardHandshake' => '1969-12-31T16:00:00-08:00'])]), 1],
+    'empty handshake' => [status([peer(['lastWireguardHandshake' => ''])]), 1],
+    'invalid handshake' => [status([peer(['lastWireguardHandshake' => 'not a date'])]), 1],
+    'invalid calendar date' => [status([peer(['lastWireguardHandshake' => '2026-02-30T00:00:00Z'])]), 1],
+    'fresh handshake' => [status([peer()]), 0],
+    'formatted JSON' => [json_encode(json_decode(status([peer()])), JSON_PRETTY_PRINT), 0],
+    'fresh fractional handshake' => [status([peer(['lastWireguardHandshake' => gmdate('Y-m-d\TH:i:s') . '.123456789Z'])]), 0],
+    'fresh non-UTC handshake' => [status([peer(['lastWireguardHandshake' => gmdate('Y-m-d\TH:i:s', time() - 7 * 3600) . '-07:00'])]), 0],
+    'stale handshake' => [status([peer(['lastWireguardHandshake' => gmdate('Y-m-d\TH:i:s\Z', time() - 300)])]), 1],
+    'future handshake' => [status([peer(['lastWireguardHandshake' => gmdate('Y-m-d\TH:i:s\Z', time() + 60)])]), 1],
+    'disconnected peer with old stats' => [status([peer(['status' => 'Disconnected'])]), 1],
+    'non-Rosenpass peer with old handshake' => [status([peer(['quantumResistance' => false])]), 1],
+    'no peers' => [status([]), 0],
+    'null list when no peers' => ['{"peers":{"total":0,"details":null}}', 0],
+    'malformed JSON' => ['{"peers": broken}', 2],
+    'truncated JSON' => ['{"peers":', 2],
+    'missing details' => ['{"peers":{"total":1}}', 2],
+    'missing peer entries' => ['{"peers":{"total":1,"details":[]}}', 2],
+    'peer entry is not an object' => ['{"peers":{"total":1,"details":[null]}}', 2],
+    'missing status' => ['{"peers":{"total":1,"details":[{}]}}', 2],
+];
+foreach ($cases as $name => [$fixture, $expected]) {
+    check($name, runGuard($fixture)[0], $expected);
+}
+
+[$rc, $cfg, $calls] = runGuard($cases['captured Los Angeles unset handshake'][0], 'rosenpass_guard');
+check('unset timestamp triggers fallback', $rc, 1);
+check('fallback is saved', str_contains($cfg, 'ENABLE_ROSENPASS="permissive"'), true);
+check('fallback disconnects before changing mode', strpos($calls, "down\n") < strpos($calls, "up --enable-rosenpass=true --rosenpass-permissive=true\n") && str_contains($calls, "down\n"), true);
+
+[$rc, $cfg] = runGuard(status([peer()]), 'rosenpass_guard');
+check('healthy peer keeps strict', $rc, 0);
+check('healthy peer keeps configuration', str_contains($cfg, 'ENABLE_ROSENPASS="1"'), true);
+
+check('successful up without live permissive mode is a failure',
+    runGuard($cases['UTC unset handshake'][0], 'rosenpass_guard', ['NB_TEST_UP_STATUS' => status([peer()], false)])[0], 2);
+
+[$rc, , , $elapsed] = runGuard(status([]), 'rosenpass_commit_confirm', ['NB_TEST_HANG_STATUS' => '1', 'RP_CONFIRM_WINDOW' => '1']);
+check('hung status is unreadable', $rc, 2);
+check('confirmation deadline bounds a status process ignoring TERM', $elapsed < 4, true);
+check('an empty response does not hide later status errors', runGuard(status([]), 'rosenpass_commit_confirm', [
+    'RP_CONFIRM_WINDOW' => '1', 'NB_TEST_SECOND_STATUS' => '{"peers": broken}',
+])[0], 2);
+
+check('UI normalizes local zero timestamp', Netbird\pbTimestamp('0000-12-31T16:07:02-07:52'), null);
+check('UI hides local zero timestamp', Netbird\relativeTime('0000-12-31T16:07:02-07:52'), '-');
+check('UI normalizes local epoch', Netbird\pbTimestamp('1969-12-31T16:00:00-08:00'), null);
+
+$mapped = Netbird\mapGatewayStatus(['fullStatus' => ['peers' => [[
+    'connStatus' => 'Connected', 'rosenpassEnabled' => true,
+    'lastWireguardHandshake' => gmdate('Y-m-d\TH:i:s\Z'),
+]]]], 'default');
+check('gateway preserves peer Rosenpass support for UI health', Netbird\hasRosenpassHandshake($mapped['peers']['details'][0]), true);
+check('UI flags an unset handshake even on a Rosenpass peer', Netbird\hasRosenpassHandshake(peer([
+    'lastWireguardHandshake' => '0000-12-31T16:07:02-07:52',
+])), false);
+
+echo "$checks checks, $failures failures\n";
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Description

Strict mode could remain enabled without a working peer connection because the guard treated a timezone-converted unset handshake as successful. On the test NAS, NetBird reported `0000-12-31T16:07:02-07:52`, which bypassed the guard's check for `0001-01-01`.

The guard now requires a recent, valid WireGuard handshake from a connected peer advertising Rosenpass support. If verification fails, it saves permissive mode and reconnects. The status display uses the same validation.

Related to #47. This fixes the reproduced safeguard defect; the reported kernel crash remains unconfirmed.

## Changes

- Parse timestamps and structured JSON; reject unset, stale, future, and invalid handshakes.
- Bound status queries, disconnects, and reconnects; prevent an earlier empty response from hiding later status errors.
- Share handshake validation with the UI and check that the parser is installed before arming strict mode.
- Add 37 regression checks and run them in CI.

## Validation

- All 37 checks passed locally with PHP 8.2 and on the Unraid NAS.
- PHPStan, PHP-CS-Fixer, PHP/shell syntax, and package integrity checks passed.
- With NetBird 0.78.1, both Settings apply and the watchdog correctly reverted strict mode to permissive and reconnected.
- A 150-second loopback test transferred 9.38 GB at 500 Mbit/s with zero retransmissions, no new kernel messages, and no NIC errors.
- Restored the NAS's original plugin release, binary, and settings; verified checksums and connectivity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer Rosenpass peer status information, including quantum-resistance indicators.
  - Improved detection of recent, healthy Rosenpass handshakes across supported timestamp formats.

- **Bug Fixes**
  - Improved handling of invalid, incomplete, or unavailable status data.
  - Added bounded status checks to prevent stalled verification operations.
  - Refined fallback behavior and messaging when Rosenpass verification cannot be completed.

- **Documentation**
  - Added instructions for running the Rosenpass regression test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->